### PR TITLE
Update greenboot-failing-unit-1.0-1.el8.noarch.rpm download URL

### DIFF
--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -467,7 +467,7 @@
     - name: install sanely failing health check unit to test red boot status behavior
       block:
         - name: install sanely failing health check unit to test red boot status behavior
-          command: rpm-ostree install http://file-server-virt-qe-3rd.cloud.paas.psi.redhat.com/greenboot-failing-unit-1.0-1.el8.noarch.rpm
+          command: rpm-ostree install http://file-server-virt-qe-3rd.apps.ocp4.prod.psi.redhat.com/greenboot-failing-unit-1.0-1.el8.noarch.rpm
           become: yes
 
         - name: reboot to deploy new ostree commit

--- a/tasks/check-greenboot.yml
+++ b/tasks/check-greenboot.yml
@@ -95,7 +95,7 @@
 - name: install sanely failing health check unit to test red boot status behavior
   block:
     - name: install sanely failing health check unit to test red boot status behavior
-      command: rpm-ostree install http://file-server-virt-qe-3rd.cloud.paas.psi.redhat.com/greenboot-failing-unit-1.0-1.el8.noarch.rpm
+      command: rpm-ostree install http://file-server-virt-qe-3rd.apps.ocp4.prod.psi.redhat.com/greenboot-failing-unit-1.0-1.el8.noarch.rpm
       become: yes
 
     - name: reboot to deploy new ostree commit


### PR DESCRIPTION
Since ocp 3.11 will be deprecated, file server has been moved to ocp 4.6. The greenboot-failing-unit rpm package URL should be updated as well