### PR TITLE
Disable firewalld to make ostree repo happy

### DIFF
--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -65,6 +65,12 @@ function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
 }
 
+# Disalbe firewalld if firewalld gets installed
+# firewalld is not installed in PSI openstack VM
+if rpm -qa | grep -q firewalld; then
+    sudo systemctl disable firewalld --now
+fi
+
 # Install required packages
 greenprint "Install required packages"
 # Install epel repo for ansible

--- a/ostree.sh
+++ b/ostree.sh
@@ -60,6 +60,12 @@ case "${ID}-${VERSION_ID}" in
         exit 1;;
 esac
 
+# Disalbe firewalld if firewalld gets installed
+# firewalld is not installed in PSI openstack VM
+if rpm -qa | grep -q firewalld; then
+    sudo systemctl disable firewalld --now
+fi
+
 # Start image builder service
 sudo systemctl enable --now osbuild-composer.socket
 


### PR DESCRIPTION
PSI openstack vm does not have firewalld installed, disabling firewalld is not required.