### PR TITLE
Add back the console=ttyS0 to the httpboot installer

### DIFF
--- a/ostree.sh
+++ b/ostree.sh
@@ -159,7 +159,7 @@ done
 greenprint "📝 Update grub.cfg to work with HTTP boot"
 sudo tee -a "${GRUB_CFG}" > /dev/null << EOF
 menuentry 'Install Red Hat Enterprise Linux for Edge 8.4' --class fedora --class gnu-linux --class gnu --class os {
-        linuxefi /httpboot/images/pxeboot/vmlinuz inst.stage2=http://192.168.100.1/httpboot inst.ks=http://192.168.100.1/ks.cfg quiet
+        linuxefi /httpboot/images/pxeboot/vmlinuz inst.stage2=http://192.168.100.1/httpboot inst.ks=http://192.168.100.1/ks.cfg inst.text console=ttyS0,115200
         initrdefi /httpboot/images/pxeboot/initrd.img
 }
 EOF


### PR DESCRIPTION
Before the httpboot option, the virt-install was enabling the console, which is very useful for debuging.
The remote uefi boot doesn't support the option 'extra-args', so it was removed. But it can be activated at the Grub entry.