### PR TITLE
Update rhel-8-6 and rhel-9-0 repos and delete rhel-8-4 and rhel-8-5 r…

### DIFF
--- a/tools/playbook/group_vars/all
+++ b/tools/playbook/group_vars/all
@@ -8,21 +8,15 @@ repos:
   centos-stream-9:
     baseos: https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/x86_64/os/
     appstream: https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/x86_64/os/
-  rhel-8-4:
-    baseos: http://download-node-02.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/x86_64/os/
-    appstream: http://download-node-02.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/x86_64/os/
-  rhel-8-5:
-    baseos: http://download-node-02.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/x86_64/os/
-    appstream: http://download-node-02.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/x86_64/os/
   rhel-8-6:
-    baseos: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6.0/compose/BaseOS/x86_64/os/
-    appstream: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6.0/compose/AppStream/x86_64/os/
+    baseos: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/updates/RHEL-8/latest-RHEL-8.6.0/compose/BaseOS/x86_64/os/
+    appstream: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/updates/RHEL-8/latest-RHEL-8.6.0/compose/AppStream/x86_64/os/
   rhel-8-7:
     baseos: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.7.0/compose/BaseOS/x86_64/os/
     appstream: http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.7.0/compose/AppStream/x86_64/os/
   rhel-9-0:
-    baseos: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/
-    appstream: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/
+    baseos: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/
+    appstream: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/
   rhel-9-1:
     baseos: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.1.0/compose/BaseOS/x86_64/os/
     appstream: http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.1.0/compose/AppStream/x86_64/os/


### PR DESCRIPTION
Update rhel-8-6 and rhel-9-0 repos with proper URL, and delete rhel-8-4 and rhel-8-5 repos from the variables file.
These changes will avoid errors when deploying locally rhel-8-6 and rhel-9-0 VMs.