### PR TITLE
Include Fedora 39 Rawhide in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,8 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-38")
         ;;
+    "fedora-39")
+        ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;


### PR DESCRIPTION
This PR includes Fedora 39 in setup's case statement to avoid future error:

```
+ case "${ID}-${VERSION_ID}" in
+ echo 'unsupported distro: fedora-39'
```