### PR TITLE
osbuild-composer v75 revert /sysroot to RO on RHEL 8.8 and CS8

### DIFF
--- a/ostree-raw-image.sh
+++ b/ostree-raw-image.sh
@@ -69,7 +69,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="rhel8-unknown"
         ADD_SSSD="true"
         USER_IN_RAW="true"
-        SYSROOT_RO="true"
+        SYSROOT_RO="false"
         ;;
     "rhel-9.0")
         OSTREE_REF="rhel/9/${ARCH}/edge"
@@ -95,7 +95,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="centos-stream8"
         ADD_SSSD="true"
         USER_IN_RAW="true"
-        SYSROOT_RO="true"
+        SYSROOT_RO="false"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"

--- a/ostree-simplified-installer.sh
+++ b/ostree-simplified-installer.sh
@@ -78,7 +78,6 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
         IMAGE_NAME="image.raw.xz"
-        SYSROOT_RO="true"
         ;;
     "rhel-9.0")
         OSTREE_REF="rhel/9/${ARCH}/edge"
@@ -102,7 +101,6 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos-stream8"
         IMAGE_NAME="image.raw.xz"
-        SYSROOT_RO="true"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"


### PR DESCRIPTION
PR https://github.com/osbuild/osbuild-composer/pull/3276 changed /sysroot to RO on RHEL 8.8 and CS8