### PR TITLE
Use new CS8 repo URL https://composes.stream.centos.org/stream-8/production

### DIFF
--- a/.github/workflows/trigger-cs.yml
+++ b/.github/workflows/trigger-cs.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 15 * * *'
 
 env:
-  COMPOSE_URL_CS8: https://composes.centos.org
+  COMPOSE_URL_CS8: https://composes.stream.centos.org/stream-8/production
   COMPOSE_URL_CS9: https://composes.stream.centos.org/production
 
 jobs:


### PR DESCRIPTION
The old URL https://composes.centos.or has been deprecated.