### PR TITLE
Add workaround for issue #2571

### DIFF
--- a/ostree-simplified-installer.sh
+++ b/ostree-simplified-installer.sh
@@ -11,7 +11,8 @@ ARCH=$(uname -m)
 # Install fdo packages (This cannot be done in the setup.sh because fdo-admin-cli is not available on fedora)
 sudo dnf install -y fdo-admin-cli python3-pip
 # Install yq to modify service api server config yaml file
-sudo pip3 install yq
+# Workaround issue https://github.com/virt-s1/rhel-edge/issues/2571
+sudo pip3 install yq==3.1.1
 # Start fdo-aio to have /etc/fdo/aio folder
 sudo systemctl enable --now fdo-aio
 # Prepare service api server config file


### PR DESCRIPTION
This PR forces the installation of yq version 3.1.1 in edge-simplified-installer. 

The selected version is yq-3-1-1, and have not shown any issue in RHEL-8.6.0-updates-20230403.5 compose.

The version that have issues in RHEL-8.6.0-updates-20230404.4 is yq-3-2-0.