### PR TITLE
Test fedora minimal embedded container in downstream

### DIFF
--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -618,6 +618,24 @@
       when:
         - embedded_container == "true"
 
+    - name: embedded fedora-minimal container image should be listed by podman images
+      block:
+        - assert:
+            that:
+              - "'localhost/fedora-minimal' in result_podman_images.stdout"
+            fail_msg: "fedora-minimal image is not built in image"
+            success_msg: "fedora-minimal image is built in image"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - embedded_container == "true"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
     # case: check running container with podman
     # bug https://bugzilla.redhat.com/show_bug.cgi?id=2123611 fix is not landed on CS8
     - name: run ubi8 image with root
@@ -684,6 +702,39 @@
             (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('8.6', '>') and ansible_facts ['distribution_version'] is version('9.0', '!=')) or
             (ansible_facts['distribution'] == 'CentOS' and ansible_facts ['distribution_version'] is version('8', '!=')) or
             (ansible_facts['distribution'] == 'Fedora')
+
+    # case: check fedora-minimal container with podman
+    - name: run fedora-minimal image
+      command: podman run localhost/fedora-minimal@sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b cat /etc/os-release
+      register: fminimal_container_result
+      become: yes
+      retries: 30  # due to https://github.com/osbuild/osbuild-composer/issues/2492
+      delay: 2
+      until: fminimal_container_result is success
+      ignore_errors: yes  # due to https://bugzilla.redhat.com/show_bug.cgi?id=1903983
+      when:
+        - embedded_container == "true"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
+    - name: run fedora-minimal container test
+      block:
+        - assert:
+            that:
+              - fminimal_container_result is succeeded
+              - "'Fedora Linux 36 (Container Image)' in fminimal_container_result.stdout"
+              - "'Trying to pull' not in fminimal_container_result.stdout"
+            fail_msg: "failed run fedora-minimal container with podman"
+            success_msg: "running fedora-minimal container with podman successed"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - embedded_container == "true"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
 
     # case: check dnf package and it should not be installed
     # https://github.com/osbuild/osbuild-composer/blob/master/internal/distro/rhel8/distro.go#L642

--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -50,6 +50,8 @@ KS_FILE=${HTTPD_PATH}/ks.cfg
 COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
 COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 GRUB_CFG=${HTTPD_PATH}/httpboot/EFI/BOOT/grub.cfg
+FEDORA_IMAGE_DIGEST="sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+FEDORA_LOCAL_NAME="localhost/fedora-minimal:v1"
 
 # SSH setup.
 SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
@@ -599,6 +601,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 
@@ -950,6 +956,10 @@ if [[ "${CONTAINER_PUSHING_FEAT}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 

--- a/ostree.sh
+++ b/ostree.sh
@@ -31,6 +31,8 @@ FIREWALL_FEATURE="false"
 # Mount /sysroot as RO by new ostree-libs-2022.6-3.el9.x86_64
 # It's RHEL 9.2 and above, CS9, Fedora 37 and above ONLY
 SYSROOT_RO="false"
+FEDORA_IMAGE_DIGEST="sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+FEDORA_LOCAL_NAME="localhost/fedora-minimal:v1"
 
 # Set os-variant and boot location used by virt-install.
 case "${ID}-${VERSION_ID}" in
@@ -392,6 +394,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 
@@ -592,6 +598,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 


### PR DESCRIPTION
This pull request includes another embedded container in edge-commit and edge-installer blueprints, just like container-embedding.sh upstream test case.
Playbook tasks have been included to check the fedora minimal container image is embedded, and the image is not being pulled again (task fails if podman try to pull latest tag).