### PR TITLE
Add Fedora aarch64 embedded container image

### DIFF
--- a/arm-commit.sh
+++ b/arm-commit.sh
@@ -174,6 +174,8 @@ KS_FILE=${COMMIT_HTTPD_PATH}/ks.cfg
 OS_NAME="rhel-edge"
 PROD_REPO_ADDRESS=192.168.100.1
 PROD_REPO_URL="http://${PROD_REPO_ADDRESS}/${TEST_OS}-commit/repo/"
+FEDORA_IMAGE_DIGEST="sha256:8fd6ac4c552bbec7910df7b0625310561d56513ecbcc418825a2f5635efecfab"
+FEDORA_LOCAL_NAME="localhost/fedora-aarch64:v1"
 
 # Download guest image
 sudo curl --no-progress-meter -o "${GUEST_IMAGE_PATH}" "${GUEST_IMAGE_URL}/${GUEST_IMAGE_NAME}"
@@ -285,6 +287,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/edge/rhel-edge/fedora-aarch64@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 
@@ -498,6 +504,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/edge/rhel-edge/fedora-aarch64@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 

--- a/arm-installer.sh
+++ b/arm-installer.sh
@@ -161,6 +161,8 @@ DIRS_FILES_CUSTOMIZATION="true"
 # Mount /sysroot as RO by new ostree-libs-2022.6-3.el9.x86_64
 # It's RHEL 9.2 and above, CS9, Fedora 37 and above ONLY
 SYSROOT_RO="false"
+FEDORA_IMAGE_DIGEST="sha256:8fd6ac4c552bbec7910df7b0625310561d56513ecbcc418825a2f5635efecfab"
+FEDORA_LOCAL_NAME="localhost/fedora-aarch64:v1"
 
 # Prepare cloud-init data
 CLOUD_INIT_DIR=$(mktemp -d)
@@ -360,6 +362,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/edge/rhel-edge/fedora-aarch64@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 
@@ -600,6 +606,10 @@ if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[containers]]
 source = "quay.io/fedora/fedora:latest"
+
+[[containers]]
+source = "registry.gitlab.com/redhat/edge/rhel-edge/fedora-aarch64@${FEDORA_IMAGE_DIGEST}"
+name = "${FEDORA_LOCAL_NAME}"
 EOF
 fi
 

--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -637,6 +637,26 @@
         - ansible_architecture == "x86_64"
         - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
 
+    - name: embedded fedora-aarch64 container image should be listed by podman images
+      block:
+        - assert:
+            that:
+              - "'localhost/fedora-aarch64' in result_podman_images.stdout"
+            fail_msg: "fedora-aarch64 image is not built in image"
+            success_msg: "fedora-aarch64 image is built in image"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - embedded_container == "true"
+        - ansible_architecture == "aarch64"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
+
     # case: check running container with podman
     # bug https://bugzilla.redhat.com/show_bug.cgi?id=2123611 fix is not landed on CS8
     - name: run ubi8 image with root
@@ -738,6 +758,41 @@
         - embedded_container == "true"
         - ansible_architecture == "x86_64"
         - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
+    # case: check fedora-aarch64 container with podman
+    - name: run fedora-aarch64 image
+      command: podman run localhost/fedora-aarch64@sha256:8fd6ac4c552bbec7910df7b0625310561d56513ecbcc418825a2f5635efecfab cat /etc/os-release
+      register: faarch64_container_result
+      become: yes
+      retries: 30  # due to https://github.com/osbuild/osbuild-composer/issues/2492
+      delay: 2
+      until: faarch64_container_result is success
+      ignore_errors: yes  # due to https://bugzilla.redhat.com/show_bug.cgi?id=1903983
+      when:
+        - embedded_container == "true"
+        - ansible_architecture == "aarch64"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
+    - name: run fedora-aarch64 container test
+      block:
+        - assert:
+            that:
+              - faarch64_container_result is succeeded
+              - "'Trying to pull' not in faarch64_container_result.stdout"
+            fail_msg: "failed run fedora-aarch64 container with podman"
+            success_msg: "running fedora-aarch64 container with podman successed"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - embedded_container == "true"
+        - ansible_architecture == "aarch64"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.2', '>='))
+
 
     # case: check dnf package and it should not be installed
     # https://github.com/osbuild/osbuild-composer/blob/master/internal/distro/rhel8/distro.go#L642


### PR DESCRIPTION
This PR includes the Fedora embedded container image for aarch64 architecture in edge-commit and edge-installer tests.
The container image was previously uploaded to the Gitlab Container Registry of our project rhel-edge.