### PR TITLE
add more wait time until fdouser present

### DIFF
--- a/ostree-fdo-container.sh
+++ b/ostree-fdo-container.sh
@@ -602,7 +602,7 @@ EOF
 # Workaround to fix edge-simplified-installer test failure (ansible runs before fdouser is created)
 # Bug link: https://github.com/osbuild/osbuild-composer/pull/3378#issuecomment-1502633131
 greenprint "🕹 Check if user 'fdouser' exist in edge vm"
-for _ in $(seq 0 30); do
+for _ in $(seq 0 60); do
     FDOUSER_EXIST=$(ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@$PUB_KEY_GUEST_ADDRESS "grep fdouser /etc/passwd")
     if [[ ${FDOUSER_EXIST} =~ "fdouser" ]]; then
         echo "fdouser has been created"


### PR DESCRIPTION
script timeout in 300 seconds if fdouser is not created, now extend it to 600 seconds to avoid failure.