### PR TITLE
add rhel9.3 support in test case

### DIFF
--- a/ostree-ignition.sh
+++ b/ostree-ignition.sh
@@ -55,6 +55,10 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
         ;;
+    "rhel-9.3")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos-stream9"

--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -108,6 +108,16 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         DIRS_FILES_CUSTOMIZATION="true"
         ;;
+    "rhel-9.3")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        NEW_MKKSISO="true"
+        CONTAINER_PUSHING_FEAT="true"
+        EMBEDDED_CONTAINER="true"
+        HTTP_BOOT_FEAT="true"
+        SYSROOT_RO="true"
+        DIRS_FILES_CUSTOMIZATION="true"
+        ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos-stream8"

--- a/ostree-raw-image.sh
+++ b/ostree-raw-image.sh
@@ -90,6 +90,13 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_RAW="true"
         SYSROOT_RO="true"
         ;;
+    "rhel-9.3")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        ADD_SSSD="true"
+        USER_IN_RAW="true"
+        SYSROOT_RO="true"
+        ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos-stream8"

--- a/ostree-simplified-installer.sh
+++ b/ostree-simplified-installer.sh
@@ -103,6 +103,16 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_BLUEPRINT="true"
         BLUEPRINT_USER="simple"
         ;;
+    "rhel-9.3")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        IMAGE_NAME="image.raw.xz"
+        SYSROOT_RO="true"
+        ANSIBLE_USER=fdouser
+        FDO_USER_ONBOARDING="true"
+        USER_IN_BLUEPRINT="true"
+        BLUEPRINT_USER="simple"
+        ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos-stream8"

--- a/ostree.sh
+++ b/ostree.sh
@@ -97,6 +97,18 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         DIRS_FILES_CUSTOMIZATION="true"
         ;;
+    "rhel-9.3")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        USER_IN_COMMIT="true"
+        OS_VARIANT="rhel9-unknown"
+        BOOT_LOCATION="http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/latest-RHEL-9.3.0/compose/BaseOS/x86_64/os/"
+        CUT_DIRS=8
+        ADD_SSSD="true"
+        EMBEDDED_CONTAINER="true"
+        FIREWALL_FEATURE="true"
+        SYSROOT_RO="true"
+        DIRS_FILES_CUSTOMIZATION="true"
+        ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         USER_IN_COMMIT="true"


### PR DESCRIPTION
Added rhel9.3 support in following test cases:
ostree-ignition.sh ostree-ng.sh ostree-raw-image.sh ostree-simplified-installer.sh ostree.sh

No need to run CI as 9.3 trigger is not added yet.