### PR TITLE
Workaround bug BZ#2124239 on RHEL 8.9 for edge-installer for http boot

### DIFF
--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -497,7 +497,7 @@ EOF
     sudo qemu-img create -f qcow2 "${LIBVIRT_HTTP_IMAGE_PATH}" 20G
 
     # Workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2124239
-    if [[ "${VERSION_ID}" == "8.7" ]]; then
+    if [[ "${VERSION_ID}" == "8.7" || "${VERSION_ID}" == "8.9" ]]; then
         ALLOC_VM_RAM=4096
     fi
 


### PR DESCRIPTION
Found same bug https://bugzilla.redhat.com/show_bug.cgi?id=2124239 on RHEL 8.9 for edge-installer for http boot. This PR includes workaround for RHEL 8.9.