### PR TITLE
Fix syntax parenthesis in Github Actions Workflows

### DIFF
--- a/.github/workflows/rhel-8-6.yml
+++ b/.github/workflows/rhel-8-6.yml
@@ -13,7 +13,7 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel-8-6-virt') ||
             endsWith(github.event.comment.body, '/test-rhel-8-6-ng') ||
             endsWith(github.event.comment.body, '/test-rhel-8-6-raw') ||
-            endsWith(github.event.comment.body, '/test-rhel-8-6-simplified') }}
+            endsWith(github.event.comment.body, '/test-rhel-8-6-simplified')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions

--- a/.github/workflows/rhel-8-7.yml
+++ b/.github/workflows/rhel-8-7.yml
@@ -13,7 +13,7 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel-8-7-virt') ||
             endsWith(github.event.comment.body, '/test-rhel-8-7-ng') ||
             endsWith(github.event.comment.body, '/test-rhel-8-7-raw') ||
-            endsWith(github.event.comment.body, '/test-rhel-8-7-simplified') }}
+            endsWith(github.event.comment.body, '/test-rhel-8-7-simplified')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions

--- a/.github/workflows/rhel-8-8.yml
+++ b/.github/workflows/rhel-8-8.yml
@@ -13,7 +13,7 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel-8-8-virt') ||
             endsWith(github.event.comment.body, '/test-rhel-8-8-ng') ||
             endsWith(github.event.comment.body, '/test-rhel-8-8-raw') ||
-            endsWith(github.event.comment.body, '/test-rhel-8-8-simplified') }}
+            endsWith(github.event.comment.body, '/test-rhel-8-8-simplified')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions

--- a/.github/workflows/rhel-8-9.yml
+++ b/.github/workflows/rhel-8-9.yml
@@ -13,7 +13,7 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel-8-9-virt') ||
             endsWith(github.event.comment.body, '/test-rhel-8-9-ng') ||
             endsWith(github.event.comment.body, '/test-rhel-8-9-raw') ||
-            endsWith(github.event.comment.body, '/test-rhel-8-9-simplified') }}
+            endsWith(github.event.comment.body, '/test-rhel-8-9-simplified')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions


### PR DESCRIPTION
This PR includes a missing parenthesis to fix errors such as:

```
[virt-s1/rhel-edge] Run failed at startup: Run Edge Test on RHEL 8.8 - main (f018d78)
Invalid workflow file: .github/workflows/rhel-8-8.yml#L11
The workflow is not valid. .github/workflows/rhel-8-8.yml (Line: 11, Col: 9): Unexpected end of expression: ')'. Located at position 340 within expression: github.event.issue.pull_request && (endsWith(github.event.comment.body, '/test-rhel-8-8') || endsWith(github.event.comment.body, '/test-rhel-8-8-virt') || endsWith(github.event.comment.body, '/test-rhel-8-8-ng') || endsWith(github.event.comment.body, '/test-rhel-8-8-raw') || endsWith(github.event.comment.body, '/test-rhel-8-8-simplified')
```