### PR TITLE
ci: ignore shellcheck sc2016

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@master
         env:
-          SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
+          SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317 -e SC2016
 
   yamllint:
     name: "🔬 yamlint"


### PR DESCRIPTION
This PR ignores the Shellcheck error SC2016 

`Expressions don't expand in single quotes, use double quotes for that.`

After some research, it has been seen that this error has exceptions https://www.shellcheck.net/wiki/SC2016 and can be ignored if we want the expression without expansion.

This is a workaround for Shellcheck error https://github.com/virt-s1/rhel-edge/pull/4209 