### PR TITLE
test: add workaround for bug BZ#2234390 cs9 edge-commit boot location

### DIFF
--- a/ostree.sh
+++ b/ostree.sh
@@ -134,6 +134,7 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="centos/9/${ARCH}/edge"
         USER_IN_COMMIT="true"
         OS_VARIANT="centos-stream9"
+        BOOT_LOCATION="https://composes.stream.centos.org/production/CentOS-Stream-9-20230823.0/compose/BaseOS/x86_64/os/"
         CUT_DIRS=6
         ADD_SSSD="true"
         EMBEDDED_CONTAINER="true"
@@ -196,10 +197,6 @@ esac
 if [[ "${ID}-${VERSION_ID}" == "centos-8" ]]; then
     CURRENT_COMPOSE_CS8=$(curl -s "https://composes.stream.centos.org/stream-8/production/" | grep -ioE ">CentOS-Stream-8-.*/<" | tr -d '>/<' | tail -1)
     BOOT_LOCATION="https://composes.stream.centos.org/stream-8/production/${CURRENT_COMPOSE_CS8}/compose/BaseOS/x86_64/os/"
-fi
-if [[ "${ID}-${VERSION_ID}" == "centos-9" ]]; then
-    CURRENT_COMPOSE_CS9=$(curl -s "https://composes.stream.centos.org/production/" | grep -ioE ">CentOS-Stream-9-.*/<" | tr -d '>/<' | tail -1)
-    BOOT_LOCATION="https://composes.stream.centos.org/production/${CURRENT_COMPOSE_CS9}/compose/BaseOS/x86_64/os/"
 fi
 
 # Colorful output.


### PR DESCRIPTION
Add workaround for cs9 edge-commit failure caused by https://bugzilla.redhat.com/show_bug.cgi?id=2234390 Kernel bug.