### PR TITLE
ci: fix aws ami cleanup bucket list error

### DIFF
--- a/tools/aws-ami-cleanup.sh
+++ b/tools/aws-ami-cleanup.sh
@@ -46,7 +46,7 @@ greenprint "Checking AWS S3 Idle Buckets 🪣"
 aws s3 ls \
     | grep -e "${UPSTREAM_PREFIX_NAME}" \
     -e "${DOWNSTREAM_PREFIX_NAME}" \
-    > "${BUCKET_LIST}"
+    > "${BUCKET_LIST}" || :
 if [[ -z $(cat "${BUCKET_LIST}") ]]; then
     echo "No buckets to remove"
 else


### PR DESCRIPTION
When there is no buckets created by our rhel-edge-ci or composer-ci, the awscli command `aws s3 ls` fails. Therefore we should ignore this error in order to continue the execution of the script.