### PR TITLE
ci: do not run ami cleanup job on any fork repos

### DIFF
--- a/.github/workflows/cleanup-aws-ami.yaml
+++ b/.github/workflows/cleanup-aws-ami.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   cleanup-ami:
+    # Do not run this job on any fork repos
+    if: github.repository == 'virt-s1/rhel-edge'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
I have seen the ami cleanup workflow being triggered in my fork repo. The workflow fails due to AWS credentials issue, and is not even meant to be run on fork repos.

This PR avoids ami cleanup job from running on any fork repos.