### PR TITLE
test: enable persistent log on Fedora 40 for ARM

### DIFF
--- a/check-minimal.yaml
+++ b/check-minimal.yaml
@@ -63,12 +63,12 @@
         path: /var/log/journal
         state: directory
       become: yes
-      when: ansible_facts['distribution'] == 'RedHat' or ansible_facts['distribution'] == 'CentOS' or (ansible_facts['architecture'] == "aarch64" and ansible_facts['distribution_version'] == "39")
+      when: ansible_facts['distribution'] == 'RedHat' or ansible_facts['distribution'] == 'CentOS' or (ansible_facts['architecture'] == "aarch64" and (ansible_facts['distribution_version'] == "39" or ansible_facts['distribution_version'] == "40"))
 
     - name: enable persistent logging on RHEL 9, CS9 and Fedora 39 for ARM
       command: journalctl --flush
       become: yes
-      when: ansible_facts['distribution_version'] == "9.4" or ansible_facts['distribution_version'] == "9.3" or ansible_facts['distribution_version'] == "9" or (ansible_facts['architecture'] == "aarch64" and ansible_facts['distribution_version'] == "39")
+      when: ansible_facts['distribution_version'] == "9.4" or ansible_facts['distribution_version'] == "9.3" or ansible_facts['distribution_version'] == "9" or (ansible_facts['architecture'] == "aarch64" and (ansible_facts['distribution_version'] == "39" or ansible_facts['distribution_version'] == "40"))
 
     - name: add RHEL 9.4 BaseOS repository
       yum_repository:


### PR DESCRIPTION
In order to circumvent  [issue#5379](https://github.com/virt-s1/rhel-edge/issues/5379) we need to enable persistent logging on Fedora Rawhide (40) for ARM.