### PR TITLE
check dmesg with privileges to avoid read kernel buffer failure

### DIFF
--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -543,12 +543,14 @@
     # case: check dmesg error and failed log
     - name: check dmesg output
       command: dmesg
+      become: yes
 
     # Ignore ignition first attempt error log, it'll be successful at the second attempt
     # e.g. ignition[630]: GET error: Get "http://192.168.100.1/ignition/config.ign": dial tcp 192.168.100.1:80: connect: network is unreachable
     - name: check dmesg error and fail log
       shell: dmesg --notime | grep -i "error\|fail" | grep -v "skipped" | grep -v "failover" | grep -v "ignition" | grep -v "BAR 13":" failed to assign" || true
       register: result_dmesg_error
+      become: yes
 
     - name: no more error or failed log
       block:


### PR DESCRIPTION
This is a suggested workaround for issue https://github.com/virt-s1/rhel-edge/issues/5955 