### PR TITLE
ci: update arm tests from fedora-38 to fedora-39

### DIFF
--- a/.github/workflows/arm-fedora-39.yml
+++ b/.github/workflows/arm-fedora-39.yml
@@ -1,5 +1,5 @@
 ---
-name: Run Edge ARM64 Test on Fedora 38
+name: Run Edge ARM64 Test on Fedora 39
 
 on:
   issue_comment:
@@ -9,10 +9,10 @@ on:
 jobs:
   pr-info:
     if: ${{ github.event.issue.pull_request &&
-            (endsWith(github.event.comment.body, '/arm-f38-all') ||
-            endsWith(github.event.comment.body, '/arm-f38-commit') ||
-            endsWith(github.event.comment.body, '/arm-f38-installer') ||
-            endsWith(github.event.comment.body, '/arm-f38-raw')) }}
+            (endsWith(github.event.comment.body, '/arm-f39-all') ||
+            endsWith(github.event.comment.body, '/arm-f39-commit') ||
+            endsWith(github.event.comment.body, '/arm-f39-installer') ||
+            endsWith(github.event.comment.body, '/arm-f39-raw')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions
@@ -43,13 +43,13 @@ jobs:
       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
       sha: ${{ fromJson(steps.pr-api.outputs.data).head.sha }}
 
-  pre-arm-all-f38:
+  pre-arm-all-f39:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            endsWith(github.event.comment.body, '/arm-f38-all') }}
+            endsWith(github.event.comment.body, '/arm-f39-all') }}
     runs-on: ubuntu-latest
     env:
-      STATUS_NAME: arm-all-f38
+      STATUS_NAME: arm-all-f39
 
     steps:
       - name: Create in-progress status
@@ -63,11 +63,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  arm-all-f38:
-    needs: [pr-info, pre-arm-all-f38]
-    runs-on: [kite, aarch64, beaker, fedora-37]
+  arm-all-f39:
+    needs: [pr-info, pre-arm-all-f39]
+    runs-on: [kite, aarch64, beaker, fedora-39]
     env:
-      STATUS_NAME: arm-all-f38
+      STATUS_NAME: arm-all-f39
 
     steps:
       - name: Create in-progress status
@@ -95,12 +95,12 @@ jobs:
         run: sudo chmod 600 key/ostree_key
 
       - name: run arm-commit.sh
-        run: ./arm-commit.sh fedora-38
+        run: ./arm-commit.sh fedora-39
         timeout-minutes: 120
 
       - name: run arm-installer.sh
         if: always()
-        run: ./arm-installer.sh fedora-38
+        run: ./arm-installer.sh fedora-39
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: run arm-raw.sh
         if: always()
-        run: ./arm-raw.sh fedora-38
+        run: ./arm-raw.sh fedora-39
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -139,18 +139,18 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: arm-all-f38
+          name: arm-all-f39
           path: |
             *.json
             *.log
 
-  pre-arm-commit-f38:
+  pre-arm-commit-f39:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            endsWith(github.event.comment.body, '/arm-f38-commit') }}
+            endsWith(github.event.comment.body, '/arm-f39-commit') }}
     runs-on: ubuntu-latest
     env:
-      STATUS_NAME: arm-commit-f38
+      STATUS_NAME: arm-commit-f39
 
     steps:
       - name: Create in-progress status
@@ -164,11 +164,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  arm-commit-f38:
-    needs: [pr-info, pre-arm-commit-f38]
-    runs-on: [kite, aarch64, beaker, fedora-37]
+  arm-commit-f39:
+    needs: [pr-info, pre-arm-commit-f39]
+    runs-on: [kite, aarch64, beaker, fedora-39]
     env:
-      STATUS_NAME: arm-commit-f38
+      STATUS_NAME: arm-commit-f39
 
     steps:
       - name: Create in-progress status
@@ -196,7 +196,7 @@ jobs:
         run: sudo chmod 600 key/ostree_key
 
       - name: run arm-commit.sh
-        run: ./arm-commit.sh fedora-38
+        run: ./arm-commit.sh fedora-39
         timeout-minutes: 60
 
       - name: Set non cancelled result status
@@ -224,18 +224,18 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: arm-commit-f38
+          name: arm-commit-f39
           path: |
             *.json
             *.log
 
-  pre-arm-installer-f38:
+  pre-arm-installer-f39:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            endsWith(github.event.comment.body, '/arm-f38-installer') }}
+            endsWith(github.event.comment.body, '/arm-f39-installer') }}
     runs-on: ubuntu-latest
     env:
-      STATUS_NAME: arm-installer-f38
+      STATUS_NAME: arm-installer-f39
 
     steps:
       - name: Create in-progress status
@@ -249,11 +249,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  arm-installer-f38:
-    needs: [pr-info, pre-arm-installer-f38]
-    runs-on: [kite, aarch64, beaker, fedora-37]
+  arm-installer-f39:
+    needs: [pr-info, pre-arm-installer-f39]
+    runs-on: [kite, aarch64, beaker, fedora-39]
     env:
-      STATUS_NAME: arm-installer-f38
+      STATUS_NAME: arm-installer-f39
 
     steps:
       - name: Create in-progress status
@@ -281,7 +281,7 @@ jobs:
         run: sudo chmod 600 key/ostree_key
 
       - name: run arm-installer.sh
-        run: ./arm-installer.sh fedora-38
+        run: ./arm-installer.sh fedora-39
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -312,18 +312,18 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: arm-installer-f38
+          name: arm-installer-f39
           path: |
             *.json
             *.log
 
-  pre-arm-raw-f38:
+  pre-arm-raw-f39:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            endsWith(github.event.comment.body, '/arm-f38-raw') }}
+            endsWith(github.event.comment.body, '/arm-f39-raw') }}
     runs-on: ubuntu-latest
     env:
-      STATUS_NAME: arm-raw-f38
+      STATUS_NAME: arm-raw-f39
 
     steps:
       - name: Create in-progress status
@@ -337,11 +337,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  arm-raw-f38:
-    needs: [pr-info, pre-arm-raw-f38]
-    runs-on: [kite, aarch64, beaker, fedora-37]
+  arm-raw-f39:
+    needs: [pr-info, pre-arm-raw-f39]
+    runs-on: [kite, aarch64, beaker, fedora-39]
     env:
-      STATUS_NAME: arm-raw-f38
+      STATUS_NAME: arm-raw-f39
 
     steps:
       - name: Create in-progress status
@@ -369,7 +369,7 @@ jobs:
         run: sudo chmod 600 key/ostree_key
 
       - name: run arm-raw.sh
-        run: ./arm-raw.sh fedora-38
+        run: ./arm-raw.sh fedora-39
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -400,7 +400,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: arm-raw-f38
+          name: arm-raw-f39
           path: |
             *.json
             *.log

--- a/.github/workflows/trigger-arm-fedora.yaml
+++ b/.github/workflows/trigger-arm-fedora.yaml
@@ -9,12 +9,12 @@ on:
     # - cron: '0 23 * * 1,3,5'
 
 env:
-  COMPOSE_URL_F38: https://dl.fedoraproject.org/pub/fedora/linux/releases/38
-  UPDATES_URL_F38: https://dl.fedoraproject.org/pub/fedora/linux/updates/38
+  COMPOSE_URL_F39: https://dl.fedoraproject.org/pub/fedora/linux/releases/39
+  UPDATES_URL_F39: https://dl.fedoraproject.org/pub/fedora/linux/updates/39
   COMPOSE_URL_rawhide: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide
 
 jobs:
-  arm-fedora38:
+  arm-fedora39:
     if: github.repository == 'virt-s1/rhel-edge' && github.event.schedule != '0 23 * * 1,3,5'
     runs-on: ubuntu-latest
     steps:
@@ -23,22 +23,22 @@ jobs:
       - name: Get package version
         id: package_version
         run: |
-          curl -s "${COMPOSE_URL_F38}/COMPOSE_ID" --output COMPOSE_ID_F38
-          COMPOSE_ID_F38=$(cat COMPOSE_ID_F38)
+          curl -s "${COMPOSE_URL_F39}/COMPOSE_ID" --output COMPOSE_ID_F39
+          COMPOSE_ID_F39=$(cat COMPOSE_ID_F39)
 
-          OSBUILD_VERSION_F38=$(curl -s "${UPDATES_URL_F38}/Everything/aarch64/Packages/o/" | grep -ioE ">osbuild-[0-9].*<" | tr -d "><")
-          OSBUILD_COMPOSER_VERSION_F38=$(curl -s "${UPDATES_URL_F38}/Everything/aarch64/Packages/o/" | grep -ioE ">osbuild-composer-[0-9].*<" | tr -d "><")
-          COMPOSER_CLI_VERSION_F38=$(curl -s "${COMPOSE_URL_F38}/Everything/aarch64/os/Packages/w/" | grep -ioE ">weldr-client-[0-9].*<" | tr -d "><")
-          echo "osbuild_version_f38=$OSBUILD_VERSION_F38" >> $GITHUB_OUTPUT
-          echo "osbuild_composer_version_f38=$OSBUILD_COMPOSER_VERSION_F38" >> $GITHUB_OUTPUT
-          echo "composer_cli_version_f38=$COMPOSER_CLI_VERSION_F38" >> $GITHUB_OUTPUT
+          OSBUILD_VERSION_F39=$(curl -s "${UPDATES_URL_F39}/Everything/aarch64/Packages/o/" | grep -ioE ">osbuild-[0-9].*<" | tr -d "><")
+          OSBUILD_COMPOSER_VERSION_F39=$(curl -s "${UPDATES_URL_F39}/Everything/aarch64/Packages/o/" | grep -ioE ">osbuild-composer-[0-9].*<" | tr -d "><")
+          COMPOSER_CLI_VERSION_F39=$(curl -s "${COMPOSE_URL_F39}/Everything/aarch64/os/Packages/w/" | grep -ioE ">weldr-client-[0-9].*<" | tr -d "><")
+          echo "osbuild_version_f39=$OSBUILD_VERSION_F39" >> $GITHUB_OUTPUT
+          echo "osbuild_composer_version_f39=$OSBUILD_COMPOSER_VERSION_F39" >> $GITHUB_OUTPUT
+          echo "composer_cli_version_f39=$COMPOSER_CLI_VERSION_F39" >> $GITHUB_OUTPUT
 
-          echo "f38_compose=$COMPOSE_ID_F38" >> $GITHUB_OUTPUT
+          echo "f39_compose=$COMPOSE_ID_F39" >> $GITHUB_OUTPUT
 
       - name: Make change for PR creating
         run: |
-          compose_id="${{ steps.package_version.outputs.f38_compose }}"
-          echo $compose_id >> arm_f38.run
+          compose_id="${{ steps.package_version.outputs.f39_compose }}"
+          echo $compose_id >> arm_f39.run
 
       - name: Get current date
         id: date
@@ -49,34 +49,34 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "aarch64 - ${{ steps.package_version.outputs.f38_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "aarch64 - ${{ steps.package_version.outputs.f39_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr
           branch-suffix: random
           delete-branch: true
-          title: "[aarch64] Fedora 38 Test - ${{ steps.date.outputs.date }}"
-          labels: DO_NOT_MERGE,fedora-38,aarch64
+          title: "[aarch64] Fedora 39 Test - ${{ steps.date.outputs.date }}"
+          labels: DO_NOT_MERGE,fedora-39,aarch64
           body: |
-            Fedora 38 compose ${{ steps.package_version.outputs.f38_compose }}
+            Fedora 39 compose ${{ steps.package_version.outputs.f39_compose }}
             - Date: ${{ steps.date.outputs.date }}
-            - Compose URL: "${{ env.COMPOSE_URL_F38 }}/${{ steps.package_version.outputs.f38_compose }}"
+            - Compose URL: "${{ env.COMPOSE_URL_F39 }}/${{ steps.package_version.outputs.f39_compose }}"
             - Packages:
-                - ${{ steps.package_version.outputs.osbuild_version_f38 }}
-                - ${{ steps.package_version.outputs.osbuild_composer_version_f38 }}
-                - ${{ steps.package_version.outputs.composer_cli_version_f38 }}
+                - ${{ steps.package_version.outputs.osbuild_version_f39 }}
+                - ${{ steps.package_version.outputs.osbuild_composer_version_f39 }}
+                - ${{ steps.package_version.outputs.composer_cli_version_f39 }}
 
       - name: Add a comment to trigger test workflow
         uses: peter-evans/create-or-update-comment@v2
         with:
           token: ${{ secrets.PAT }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}
-          body: /arm-f38-all
+          body: /arm-f39-all
 
       - name: Create a project card to track compose test result
         uses: peter-evans/create-or-update-project-card@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project-name: Fedora Compose Test
-          column-name: Fedora-38
+          column-name: Fedora-39
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Since we have disabled fedora-38, there are aarch64 workflow jobs that need to be updated.