### PR TITLE
test: remove residual configuration from edge-ami-image test case

### DIFF
--- a/ostree-ami-image.sh
+++ b/ostree-ami-image.sh
@@ -84,7 +84,6 @@ get_compose_metadata () {
 
     # Move the JSON file into place.
     sudo cat "${TEMPDIR}"/"${COMPOSE_ID}".json | jq -M '.' | tee "$METADATA_FILE" > /dev/null
-    sudo chown admin:admin "${TEMPDIR}"/"${COMPOSE_ID}".json
 }
 
 # Build ostree image.


### PR DESCRIPTION
We need to remove residual configuration line from edge-ami-image test case.