### PR TITLE
test: update minimal raw file name variables in Fedora systems

### DIFF
--- a/minimal-raw.sh
+++ b/minimal-raw.sh
@@ -49,12 +49,18 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-38")
         OS_VARIANT="fedora-unknown"
+        MINIMAL_RAW_DECOMPRESSED=disk.raw
+        MINIMAL_RAW_FILENAME=disk.raw.xz
         ;;
     "fedora-39")
         OS_VARIANT="fedora-unknown"
+        MINIMAL_RAW_DECOMPRESSED=disk.raw
+        MINIMAL_RAW_FILENAME=disk.raw.xz
         ;;
     "fedora-40")
         OS_VARIANT="fedora-rawhide"
+        MINIMAL_RAW_DECOMPRESSED=disk.raw
+        MINIMAL_RAW_FILENAME=disk.raw.xz
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"


### PR DESCRIPTION
We need to update `MINIMAL_RAW_FILENAME` and  `MINIMAL_RAW_DECOMPRESSED` variables values in Fedora systems.