### PR TITLE
test: fix ansible os name variable in edge installer

### DIFF
--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -137,6 +137,7 @@ case "${ID}-${VERSION_ID}" in
         HTTP_BOOT_FEAT="true"
         SYSROOT_RO="true"
         DIRS_FILES_CUSTOMIZATION="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
@@ -538,7 +539,7 @@ EOF
 EOF
     # Test IoT/Edge OS
     greenprint "📼 Run Edge tests on HTTPBOOT VM"
-    podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${ANSIBLE_OS_NAME}" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${ANSIBLE_OS_NAME}:${OSTREE_REF}" -e embedded_container="${EMBEDDED_CONTAINER}" -e sysroot_ro="$SYSROOT_RO" -e test_custom_dirs_files="${DIRS_FILES_CUSTOMIZATION}" check-ostree.yaml || RESULTS=0
+    podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="rhel" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="rhel:${OSTREE_REF}" -e embedded_container="${EMBEDDED_CONTAINER}" -e sysroot_ro="$SYSROOT_RO" -e test_custom_dirs_files="${DIRS_FILES_CUSTOMIZATION}" check-ostree.yaml || RESULTS=0
     check_result
 
     greenprint "🧹 Clean up HTTPBOOT VM"
@@ -924,7 +925,7 @@ version = "*"
 EOF
 
 # ANSIBLE_OS_NAME is a check-ostree.yaml playbook variable defined as "rhel" just for RHEL and CS systems, otherwise is "fedora"
-if [[ "${ANSIBLE_OS_NAME}" == "rhel" ]]; then
+if [[ "${ANSIBLE_OS_NAME}" == "rhel" || "${ANSIBLE_OS_NAME}" == "rhel-edge" ]]; then
     tee -a "$BLUEPRINT_FILE" >> /dev/null << EOF
 [customizations.kernel]
 name = "kernel-rt"


### PR DESCRIPTION
ANSIBLE_OS_NAME variable value has changed from rhel to rhel-edge in edge installer test case RHEL-9.5, we need to update this variable.