### PR TITLE
ci: disable cases in rhel8

### DIFF
--- a/.github/workflows/rhel-8-10.yml
+++ b/.github/workflows/rhel-8-10.yml
@@ -63,7 +63,7 @@ jobs:
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
-          tmt_context: "arch=x86_64;distro=rhel;version=8.10"
+          tmt_context: "arch=x86_64;distro=rhel-8-10"
           pull_request_status_name: "edge-rhel-8.10-x86"
           tmt_plan_regex: edge-x86
           tf_scope: private

--- a/.github/workflows/rhel-8-8.yml
+++ b/.github/workflows/rhel-8-8.yml
@@ -63,7 +63,7 @@ jobs:
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
-          tmt_context: "arch=x86_64;distro=rhel;version=8.8"
+          tmt_context: "arch=x86_64;distro=rhel-8-8"
           pull_request_status_name: "edge-rhel-8.8-x86"
           tmt_plan_regex: edge-x86
           tf_scope: private

--- a/.github/workflows/rhel-9-4.yml
+++ b/.github/workflows/rhel-9-4.yml
@@ -63,7 +63,7 @@ jobs:
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
-          tmt_context: "arch=x86_64;distro=rhel;version=9.4"
+          tmt_context: "arch=x86_64;distro=rhel-9-4"
           pull_request_status_name: "edge-rhel-9.4-x86"
           tmt_plan_regex: edge-x86
           tf_scope: private
@@ -92,7 +92,7 @@ jobs:
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
-          tmt_context: "arch=aarch64;distro=rhel;version=9.4"
+          tmt_context: "arch=aarch64;distro=rhel-9-4"
           pull_request_status_name: "edge-rhel-9.4-arm"
           tmt_plan_regex: edge-arm
           tf_scope: private

--- a/tmt/plans/edge-test.fmf
+++ b/tmt/plans/edge-test.fmf
@@ -39,9 +39,9 @@ provision:
   adjust+:
     - when: arch != x86_64 or distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-fdo-db:
@@ -51,9 +51,9 @@ provision:
   adjust+:
     - when: arch != x86_64 or distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-ignition:
@@ -63,9 +63,9 @@ provision:
   adjust+:
     - when: arch != x86_64 or distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-pulp:
@@ -75,9 +75,9 @@ provision:
   adjust+:
     - when: arch != x86_64 or distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-vsphere:
@@ -87,9 +87,9 @@ provision:
   adjust+:
     - when: arch != x86_64 or distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-ami-image:
@@ -99,9 +99,9 @@ provision:
   adjust+:
     - when: distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-minimal:
@@ -109,7 +109,7 @@ provision:
   environment+:
     TEST_CASE: edge-minimal
   adjust+:
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
 
 /edge-x86-8to9:
@@ -119,9 +119,9 @@ provision:
   adjust+:
     - when: distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-x86-9to9:
@@ -131,9 +131,9 @@ provision:
   adjust+:
     - when: distro == fedora
       enabled: false
-    - when: distro==rhel and version == 8.8
+    - when: distro == rhel-8-8
       enabled: false
-    - when: distro==rhel and version == 8.10
+    - when: distro == rhel-8-10
       enabled: false
 
 /edge-arm-ami-image:
@@ -148,4 +148,3 @@ provision:
   summary: Test edge minimal raw image
   environment+:
     TEST_CASE: edge-minimal
-


### PR DESCRIPTION
I have tried these conditions but do not work:
1. - when: distro==rhel and version == 8.10    (tmt_context: "arch=x86_64;distro=rhel;version=8.10")
2. - when: distro==rhel and version == 810     (tmt_context: "arch=x86_64;distro=rhel;version=810")
3. - when: distro==rhel and version == "810"  (tmt_context: "arch=x86_64;distro=rhel;version=810")

so I removed version from github workflow file, and only use distro, it works now.
1. - when: distro == rhel-8-10   (tmt_context: "arch=x86_64;distro=rhel-8-10")

Please let me know if you know how to fix it and we can add version back.