### PR TITLE
ci: fix fdo db case failures on rhel9.4

### DIFF
--- a/ostree-fdo-db.sh
+++ b/ostree-fdo-db.sh
@@ -281,7 +281,7 @@ DB_TYPE=$((RANDOM % 2))
 if [[ $DB_TYPE == 0 ]]; then
     # Setup FDO SQLite database
     greenprint "🔧 FDO SQLite DB configurations"
-    cargo install --force diesel_cli --no-default-features --features sqlite
+    cargo install --force diesel_cli --version 2.1.1 --no-default-features --features sqlite
     rm -fr /tmp/fdo
     mkdir -p /tmp/fdo
     manufacturer_db_file="/tmp/fdo/manufacturer-db.sqlite"


### PR DESCRIPTION
In testing-farm machine, cargo install failed because diesel_cli 2.2.0 requires  rustc 1.78.0 or newer. Didn't see this error before, probably diesel_cli has a new version now.
As I cannot upgrade rustc to 1.78 on this machine, change to old version 2.1.1 can resolve this issue.

[root@3482cc1f-759a-497b-a104-32c635b71238 ~]# cargo install --force diesel_cli --no-default-features --features sqlite
    Updating crates.io index
error: cannot install package `diesel_cli 2.2.0`, it requires rustc 1.78.0 or newer, while the currently active rustc version is 1.75.0
`diesel_cli 2.1.1` supports rustc 1.65.0
