### PR TITLE
test: adjust os name variable in test cases

### DIFF
--- a/ostree-ami-image.sh
+++ b/ostree-ami-image.sh
@@ -20,7 +20,7 @@ CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
 RAW_TYPE=edge-ami
 RAW_FILENAME=image.raw
-ANSIBLE_OS_NAME="rhel-edge"
+ANSIBLE_OS_NAME="redhat"
 BUCKET_NAME="rhel-edge-${TEST_UUID}"
 BUCKET_URL="s3://${BUCKET_NAME}"
 OBJECT_URL="http://${BUCKET_NAME}.s3.${AWS_DEFAULT_REGION}.amazonaws.com"
@@ -42,13 +42,23 @@ EDGE_USER_PASSWORD=foobar
 sudo mkdir -p /etc/osbuild-composer/repositories
 
 case "${ID}-${VERSION_ID}" in
-    "rhel-9"*)
+    "rhel-9.3")
         OSTREE_REF="rhel/9/${ARCH}/edge"
         SYSROOT_RO="true"
+        ;;
+    "rhel-9.4")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        SYSROOT_RO="true"
+        ;;
+    "rhel-9.5")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        SYSROOT_RO="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"
         SYSROOT_RO="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"

--- a/ostree-fdo-aio.sh
+++ b/ostree-fdo-aio.sh
@@ -44,6 +44,7 @@ INSTALLER_FILENAME=simplified-installer.iso
 REF_PREFIX="rhel-edge"
 # Workaround BZ#2108646
 BOOT_ARGS="uefi"
+OS_NAME="redhat"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -157,6 +158,7 @@ case "${ID}-${VERSION_ID}" in
         FDO_USER_ONBOARDING="true"
         USER_IN_BLUEPRINT="true"
         BLUEPRINT_USER="simple"
+        OS_NAME="rhel-edge"
         ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
@@ -183,6 +185,7 @@ case "${ID}-${VERSION_ID}" in
         FDO_USER_ONBOARDING="true"
         USER_IN_BLUEPRINT="true"
         BLUEPRINT_USER="simple"
+        OS_NAME="rhel-edge"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -637,7 +640,7 @@ ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
 # Test IoT/Edge OS
-podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 
 # Check test result
 check_result
@@ -785,7 +788,7 @@ if [[ "$ANSIBLE_USER" == "fdouser" ]]; then
 fi
 
 # Test IoT/Edge OS
-podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 
 # Check test result
 check_result
@@ -923,7 +926,7 @@ if [[ "$ANSIBLE_USER" == "fdouser" ]]; then
 fi
 
 # Test IoT/Edge OS
-podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${REBASE_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${REBASE_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 
 # Check test result
 check_result
@@ -1065,7 +1068,7 @@ ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
 # Test IoT/Edge OS
-podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 
 # Check test result
 check_result
@@ -1199,7 +1202,7 @@ ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
 # Test IoT/Edge OS
-podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${UPGRADE_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${UPGRADE_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 
 # Check test result
 check_result

--- a/ostree-fdo-db.sh
+++ b/ostree-fdo-db.sh
@@ -21,6 +21,7 @@ CONTAINER_FILENAME=container.tar
 INSTALLER_TYPE=edge-simplified-installer
 INSTALLER_FILENAME=simplified-installer.iso
 REF_PREFIX="rhel-edge"
+OS_NAME="redhat"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -46,11 +47,13 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
         BOOT_ARGS="uefi"
+        OS_NAME="rhel-edge"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos-stream9"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
+        OS_NAME="rhel-edge"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -591,7 +594,7 @@ ansible_become_method=sudo
 EOF
 
 # Test IoT/Edge OS
-sudo podman run -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name=rhel-edge -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
+sudo podman run -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e os_name="${OS_NAME}" -e ostree_commit="${INSTALL_HASH}" -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" check-ostree.yaml || RESULTS=0
 check_result
 
 # Clean up VM

--- a/ostree-ng.sh
+++ b/ostree-ng.sh
@@ -157,6 +157,7 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         SYSROOT_RO="true"
         DIRS_FILES_CUSTOMIZATION="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     "fedora-38")
         CONTAINER_IMAGE_TYPE=fedora-iot-container

--- a/ostree-raw-image.sh
+++ b/ostree-raw-image.sh
@@ -28,7 +28,7 @@ RAW_FILENAME=image.raw.xz
 BOOT_ARGS="uefi"
 # RHEL and CS default ostree os_name is redhat
 # But Fedora uses fedora-iot
-ANSIBLE_OS_NAME="rhel-edge"
+ANSIBLE_OS_NAME="redhat"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -121,6 +121,7 @@ case "${ID}-${VERSION_ID}" in
         ADD_SSSD="true"
         USER_IN_RAW="true"
         SYSROOT_RO="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
@@ -140,6 +141,7 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         USER_IN_RAW="true"
         SYSROOT_RO="true"
+        ANSIBLE_OS_NAME="rhel-edge"
         ;;
     "fedora-38")
         CONTAINER_TYPE=fedora-iot-container

--- a/ostree-simplified-installer.sh
+++ b/ostree-simplified-installer.sh
@@ -100,7 +100,7 @@ SYSROOT_RO="false"
 
 # No FDO and Ignition in simplified installer is only supported started from 8.8 and 9.2
 NO_FDO="false"
-OS_NAME="rhel-edge"
+OS_NAME="redhat"
 
 # Prepare osbuild-composer repository file
 sudo mkdir -p /etc/osbuild-composer/repositories
@@ -201,6 +201,7 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_BLUEPRINT="true"
         BLUEPRINT_USER="simple"
         NO_FDO="true"
+        OS_NAME="rhel-edge"
         ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
@@ -229,6 +230,7 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_BLUEPRINT="true"
         BLUEPRINT_USER="simple"
         NO_FDO="true"
+        OS_NAME="rhel-edge"
         ;;
     "fedora-"*)
         OSTREE_REF="fedora/${VERSION_ID}/${ARCH}/iot"

--- a/ostree-vsphere.sh
+++ b/ostree-vsphere.sh
@@ -31,6 +31,7 @@ CONTAINER_FILENAME=container.tar
 VSPHERE_IMAGE_TYPE=edge-vsphere
 VSPHERE_FILENAME=image.vmdk
 REF_PREFIX="rhel-edge"
+OS_NAME="redhat"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -60,20 +61,36 @@ DATACENTER_70_POOL="/Datacenter7.0/host/Automation/Resources"
 
 # Workdaround for creating rhel9 and centos9 on dc67, change guest_id to 8
 case "${ID}-${VERSION_ID}" in
-    "rhel-9"* )
+    "rhel-9.3" )
         OSTREE_REF="rhel/9/${ARCH}/edge"
         # GUEST_ID_DC67="rhel8_64Guest"
         GUEST_ID_DC70="rhel9_64Guest"
+        ;;
+    "rhel-9.4" )
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        # GUEST_ID_DC67="rhel8_64Guest"
+        GUEST_ID_DC70="rhel9_64Guest"
+        ;;
+    "rhel-9.5" )
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        # GUEST_ID_DC67="rhel8_64Guest"
+        GUEST_ID_DC70="rhel9_64Guest"
+        OS_NAME="rhel-edge"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"
         # GUEST_ID_DC67="centos8_64Guest"
         GUEST_ID_DC70="centos9_64Guest"
+        OS_NAME="rhel-edge"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
+
+if [[ "${ID}-${VERSION_ID}" == "rhel-9.5" ]]; then
+   OS_NAME="rhel-edge"
+fi
 
 # Colorful output.
 function greenprint {
@@ -486,7 +503,7 @@ EOF
 podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z \
     --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory \
     -e ignition="true" \
-    -e os_name=rhel-edge \
+    -e os_name="${OS_NAME}" \
     -e ostree_commit="${INSTALL_HASH}" \
     -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" \
     -e fdo_credential="false" \
@@ -681,7 +698,7 @@ EOF
 podman run --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z \
     --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory \
     -e ignition="true" \
-    -e os_name=rhel-edge \
+    -e os_name="${OS_NAME}" \
     -e ostree_commit="${UPGRADE_HASH}" \
     -e ostree_ref="${REF_PREFIX}:${OSTREE_REF}" \
     -e fdo_credential="false" \


### PR DESCRIPTION
We have seen in our downstream CI several failed tests due to inconsistency of os name (or ansible os name) variable across distros. Thus, playbook tasks such as find /var /mnt mount points failed.

This PR configures mentioned variable value to `rhel-edge` only when test are perfomed by RHEL-9.5, centos-stream-9. In addition edge-commit will also have `rhel-edge` variable value across all distros under test.