### PR TITLE
test: update minimal image name in rhel-9.4

### DIFF
--- a/minimal-raw.sh
+++ b/minimal-raw.sh
@@ -37,7 +37,13 @@ case "${ID}-${VERSION_ID}" in
     "rhel-8"*)
         OS_VARIANT="rhel8-unknown"
         ;;
-    "rhel-9"*)
+    "rhel-9.3")
+        OS_VARIANT="rhel9-unknown"
+        ;;
+    "rhel-9.4")
+        OS_VARIANT="rhel9-unknown"
+        ;;
+    "rhel-9.5")
         OS_VARIANT="rhel9-unknown"
         MINIMAL_RAW_DECOMPRESSED=disk.raw
         MINIMAL_RAW_FILENAME=disk.raw.xz


### PR DESCRIPTION
Following rhel-9.4 tests are failing:
https://artifacts.osci.redhat.com/testing-farm/91e03f1f-df69-4cfe-8abe-ac1a52611e5e/work-edge-arm-minimalepiqi6tx/tmt/plans/edge-test/edge-arm-minimal/execute/data/guest/default-0/tmt/tests/edge-test-1/output.txt

https://artifacts.osci.redhat.com/testing-farm/aaee6ea8-384a-4309-b776-50d61800bf39/work-edge-x86-minimalgd6vl8mj/tmt/plans/edge-test/edge-x86-minimal/execute/data/guest/default-0/tmt/tests/edge-test-1/output.txt

We should use proper minimal image name in rhel-9.4.