### PR TITLE
ci: increase testing-farm processor and memory resources

### DIFF
--- a/tmt/plans/edge-test.fmf
+++ b/tmt/plans/edge-test.fmf
@@ -9,8 +9,8 @@ provision:
     virtualization:
       is-supported: true
     cpu:
-      processors: ">= 2"
-    memory: ">= 6 GB"
+      processors: ">= 4"
+    memory: ">= 8 GB"
 
 /edge-x86-commit:
   summary: Test edge commit


### PR DESCRIPTION
Following Xiaofeng's suggestion, let's increase some processor and memory resources allocated to testing-farm machines to try to circumvent issue https://issues.redhat.com/browse/TFT-2699