### PR TITLE
ci: fix fdo container workflow job dependency

### DIFF
--- a/.github/workflows/fdo-container.yml
+++ b/.github/workflows/fdo-container.yml
@@ -44,7 +44,7 @@ jobs:
       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
 
   fdo-container-community:
-    needs: [pr-info, pre-fdo-container-community]
+    needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1;FDO_REGISTRY=quay.io/fido-fdo; OWNER_ONBOARDING_SERVER_NAME=owner-onboarding-server; MANUFACTURING_SERVER_NAME=manufacturing-server; RENDEZVOUS_SERVER_NAME=rendezvous-server; SERVICEINFO_API_SERVER_NAME=serviceinfo-api-server"
 
   fdo-container-official:
-    needs: [pr-info, pre-fdo-container-official]
+    needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
     continue-on-error: true
     runs-on: ubuntu-latest


### PR DESCRIPTION
The fdo container workflow jobs are not being triggered due to the following error:

```
Invalid workflow file: .github/workflows/fdo-container.yml#L47
The workflow is not valid. .github/workflows/fdo-container.yml (Line: 47, Col: 22): Job 'fdo-container-community' depends on unknown job 'pre-fdo-container-community'. .github/workflows/fdo-container.yml (Line: 78, Col: 22): Job 'fdo-container-official' depends on unknown job 'pre-fdo-container-official'.
```
In order to fix it, we need to delete the unknown job 'pre-fdo-container-official'.