### PR TITLE
ci: update fdo official container test compose to rhel-9.5

### DIFF
--- a/.github/workflows/fdo-container.yml
+++ b/.github/workflows/fdo-container.yml
@@ -92,14 +92,14 @@ jobs:
       - name: run ostree-fdo-container.sh
         uses: sclorg/testing-farm-as-github-action@v3.1.0
         with:
-          compose: RHEL-9.4.0-Nightly
+          compose: RHEL-9.5.0-Nightly
           arch: x86_64
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
-          tmt_context: "arch=x86_64;distro=rhel-9-4"
-          pull_request_status_name: "edge-rhel-9-4-x86"
+          tmt_context: "arch=x86_64;distro=rhel-9-5"
+          pull_request_status_name: "edge-rhel-9-5-x86"
           tmt_plan_regex: edge-fdo-container
           tf_scope: private
           secrets: "DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};OCP4_TOKEN=${{ secrets.OCP4_TOKEN }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }};DOCKERHUB_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};GOVC_URL=${{ secrets.GOVC_URL }};GOVC_USERNAME=${{ secrets.GOVC_USERNAME }};GOVC_PASSWORD=${{ secrets.GOVC_PASSWORD }};FDO_REGISTRY=${{ secrets.FDO_OFFICIAL_REGISTRY }}"


### PR DESCRIPTION
We need to update the compose from rhel-9.4 to rhel-9.5 of the ostree fdo official container test.