### PR TITLE
ci: update testing-farm-as-github-action to v3.1.2

### DIFF
--- a/.github/workflows/fedora-40.yml
+++ b/.github/workflows/fedora-40.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}

--- a/.github/workflows/fedora-41.yml
+++ b/.github/workflows/fedora-41.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-41
           api_key: ${{ secrets.TF_API_KEY }}
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-41
           api_key: ${{ secrets.TF_API_KEY }}

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-Rawhide-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-Rawhide-Nightly
           api_key: ${{ secrets.TF_API_KEY }}

--- a/.github/workflows/rhel-8-8.yml
+++ b/.github/workflows/rhel-8-8.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: RHEL-8.8.0-Nightly
           arch: x86_64

--- a/.github/workflows/rhel-9-4.yml
+++ b/.github/workflows/rhel-9-4.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: RHEL-9.4.0-Nightly
           arch: x86_64
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: RHEL-9.4.0-Nightly
           arch: aarch64

--- a/.github/workflows/rhel-9-5.yml
+++ b/.github/workflows/rhel-9-5.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: RHEL-9.5.0-Nightly
           arch: x86_64
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v3.1.0
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: RHEL-9.5.0-Nightly
           arch: aarch64


### PR DESCRIPTION
In order to solve testing-farm issue https://github.com/sclorg/testing-farm-as-github-action/issues/209 that our CI has seen several times, we need to update our workflow jobs to use testing-farm-as-github-action v3.1.2