### PR TITLE
ci: fix fdo container tmt status name

### DIFF
--- a/.github/workflows/fdo-container.yml
+++ b/.github/workflows/fdo-container.yml
@@ -68,7 +68,7 @@ jobs:
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
           tmt_context: "arch=x86_64;distro=centos-stream-9"
-          pull_request_status_name: "edge-centos-stream-x86"
+          pull_request_status_name: "fdo-container-community-cs9"
           tmt_plan_regex: edge-fdo-container
           tf_scope: private
           secrets: "DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};OCP4_TOKEN=${{ secrets.OCP4_TOKEN }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }};DOCKERHUB_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};GOVC_URL=${{ secrets.GOVC_URL }};GOVC_USERNAME=${{ secrets.GOVC_USERNAME }};GOVC_PASSWORD=${{ secrets.GOVC_PASSWORD }}"
@@ -99,7 +99,7 @@ jobs:
           git_ref: ${{ needs.pr-info.outputs.ref }}
           update_pull_request_status: true
           tmt_context: "arch=x86_64;distro=rhel-9-5"
-          pull_request_status_name: "edge-rhel-9-5-x86"
+          pull_request_status_name: "fdo-container-official-rhel95"
           tmt_plan_regex: edge-fdo-container
           tf_scope: private
           secrets: "DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};OCP4_TOKEN=${{ secrets.OCP4_TOKEN }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }};DOCKERHUB_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};GOVC_URL=${{ secrets.GOVC_URL }};GOVC_USERNAME=${{ secrets.GOVC_USERNAME }};GOVC_PASSWORD=${{ secrets.GOVC_PASSWORD }};FDO_REGISTRY=${{ secrets.FDO_OFFICIAL_REGISTRY }}"


### PR DESCRIPTION
current fdo container tests have pull request status names that is not clear to tell us what's being tested.