### PR TITLE
ci: update fdo container trigger create pr and comment versions

### DIFF
--- a/.github/workflows/trigger-fdo-container.yml
+++ b/.github/workflows/trigger-fdo-container.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "FDO community container test - ${{ steps.date.outputs.date }}"
@@ -44,7 +44,7 @@ jobs:
             - Date: ${{ steps.date.outputs.date }}
 
       - name: Add a comment to trigger test workflow
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.PAT }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "FDO official container test - ${{ steps.date.outputs.date }}"
@@ -82,7 +82,7 @@ jobs:
             - Date: ${{ steps.date.outputs.date }}
 
       - name: Add a comment to trigger test workflow
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.PAT }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
FDO container test trigger jobs are failing due to:

`Error: Missing either 'issue-number' or 'comment-id'.`

Check https://github.com/virt-s1/rhel-edge/actions/runs/12065220907/job/33643538622

We need to verify if this is fixed by updating versions of `peter-evans/create-pull-request `and `peter-evans/create-or-update-comment`