### PR TITLE
ci: remove fdo-container.run file to trigger fdo container workflows properly

### DIFF
--- a/fdo-container.run
+++ b/fdo-container.run
@@ -1,1 +1,0 @@
-fdo-container


### PR DESCRIPTION
This is a suggested workaround for https://github.com/virt-s1/rhel-edge/issues/8999