### PR TITLE
ci: remove fdo-container.run file to trigger fdo container workflows properly

### DIFF
--- a/fdo-container.run
+++ b/fdo-container.run
@@ -1,1 +1,0 @@
-fdo-container


### PR DESCRIPTION
Remove fdo-container.run file to trigger fdo container workflows properly.