### PR TITLE
ci: remove fdo-container file to fix container ci trigger

### DIFF
--- a/fdo-container.run
+++ b/fdo-container.run
@@ -1,1 +1,0 @@
-fdo-container


### PR DESCRIPTION
Remove fdo-container file to fix container ci trigger.