### PR TITLE
ci:remove some test cases

### DIFF
--- a/tmt/plans/edge-test.fmf
+++ b/tmt/plans/edge-test.fmf
@@ -40,9 +40,19 @@ provision:
   environment+:
     TEST_CASE: edge-fdo-aio
   adjust+:
-    - when: arch != x86_64 or distro == fedora
+    - when: arch != x86_64
+      enabled: false
+    - when: distro == fedora
+      enabled: false
+    - when: distro==cs-9
       enabled: false
     - when: distro == rhel-8-10
+      enabled: false
+    - when: distro==rhel-9-4
+      enabled: false
+    - when: distro==rhel-9-5
+      enabled: false
+    - when: distro==rhel-9-6
       enabled: false
 
 /edge-x86-fdo-db:
@@ -76,11 +86,19 @@ provision:
   environment+:
     TEST_CASE: edge-pulp
   adjust+:
-    - when: arch != x86_64 or distro == fedora
+    - when: arch != x86_64
+      enabled: false
+    - when: distro == fedora
+      enabled: false
+    - when: distro==cs-9
       enabled: false
     - when: distro == rhel-8-10
       enabled: false
-    - when: distro==cs-9
+    - when: distro==rhel-9-4
+      enabled: false
+    - when: distro==rhel-9-5
+      enabled: false
+    - when: distro==rhel-9-6
       enabled: false
 
 /edge-x86-vsphere:


### PR DESCRIPTION
CI runs on testing-farm, but often found that testing-farm job is cancelled, because we have lots of testing-farm job running in CI, disable these two low priority test cases to reduce the testing-farm workload.

1. test case edge-x86-pulp : this test case is to push edge commit files into a pulp server, and then pull it from pulp server. Never heard of any pulp issue since this test case created, and pulp is not part of RHEL for Edge project, so consider this pulp test case as low priority.
2. test case edge-x86-fdo-aio: this test case is to setup fdo-aio server and then build and provision edge vm with it. As fdo function tests are already covered in other test cases, and fdo-aio is more likely a developer tool, and customer will not use it, so consider this fdo-aio test case as low priority.