### PR TITLE
ci: fix fedora-iot test case failures

### DIFF
--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -4,7 +4,7 @@ name: Trigger Fedora-IoT image test
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 13 * * *'
 
 env:
   COMPOSE_URL_44: https://kojipkgs.fedoraproject.org/compose/iot/latest-Fedora-IoT-44

--- a/check-ostree-iot.yaml
+++ b/check-ostree-iot.yaml
@@ -332,7 +332,7 @@
           register: result_greenboot_log
         - assert:
             that:
-              - "'FALLBACK BOOT DETECTED! Default rpm-ostree deployment has been rolled back' in result_greenboot_log.stdout"
+              - "'FALLBACK BOOT DETECTED! Default bootc deployment has been rolled back' in result_greenboot_log.stdout"
             fail_msg: "Fallback log not found"
             success_msg: "Found fallback log"
       always:


### PR DESCRIPTION
This PR includes:
1. due to a minor issue https://github.com/virt-s1/rhel-edge/issues/10847 , iot-raw-image and iot-simplified-installer test failed, modified script to make it pass.
2. change the trigger time of fedora-iot test, so it will run about 2 hours later after fedora-compose check finished.