### PR TITLE
test: add example workflow to export test run to polarion

### DIFF
--- a/.github/workflows/export-tc-to-polarion.yml
+++ b/.github/workflows/export-tc-to-polarion.yml
@@ -1,0 +1,35 @@
+name: export tmt test run to Polarion
+
+on:
+  workflow_dispatch:
+    inputs:
+      compose:
+        required: true
+        default: RHEL-9.6.0
+      arch:
+        required: true
+        default: x86_64
+
+jobs:
+  export-test-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Export the test case to Polarion
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
+        with:
+          compose: RHEL-9.6.0-Nightly
+          arch: x86_64
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.pr-info.outputs.repo_url }}
+          git_ref: ${{ needs.pr-info.outputs.ref }}
+          update_pull_request_status: true
+          tmt_context: "arch=x86_64;distro=rhel-9-6"
+          pull_request_status_name: "edge-rhel-9.6-x86"
+          tmt_plan_regex: "export-to-polarion-plan"
+          secrets: |
+            POLARION_USER=${{ secrets.POLARION_USER }}
+            POLARION_PASSWORD=${{ secrets.POLARION_PASSWORD }}
+            POLARION_PROJECT=${{ secrets.POLARION_PROJECT }}
+            POLARION_URL=${{ secrets.POLARION_URL }}

--- a/tmt/plans/export-to-polarion-plan.fmf
+++ b/tmt/plans/export-to-polarion-plan.fmf
@@ -1,0 +1,41 @@
+summary: Basic smoke test
+
+execute:
+    how: tmt
+
+discover:
+    how: fmf
+    test: export-tc-to-polarion
+
+provision:
+    hardware:
+        virtualization:
+            is-supported: true
+        cpu:
+            processors: ">= 2"
+        memory: ">= 6 GB"
+
+prepare:
+  - how: shell
+    script: |
+      # Ensure reporter and client are available (adjust if your base image has them)
+      if command -v dnf >/dev/null 2>&1; then
+        sudo dnf -y install tmt-report-polarion python3-pylero || true
+      fi
+      # Write ~/.pylero with values from env (provided by the action)
+      install -m 600 /dev/null "$HOME/.pylero"
+      cat > "$HOME/.pylero" << EOF
+      [webservice]
+      url=${POLARION_UR}L/polarion
+      svn_repo=${POLARION_URL}/repo
+      user=${POLARION_USER}
+      password=${POLARION_PASSWORD}
+      default_project=${POLARION_PROJECT}
+      EOF
+
+report:
+    how: polarion
+    file: test.xml
+    project-id: ${POLARION_PROJECT}
+    title: test_title
+    assignee: mcattamo

--- a/tmt/tests/export-tc-to-polarion.fmf
+++ b/tmt/tests/export-tc-to-polarion.fmf
@@ -1,0 +1,7 @@
+summary: Exporting test run to Polarion test
+# Example component
+component:
+  - component1
+description: This is a first test to export tmt test case run to Polarion
+contact: Mario Cattamo <mcattamo@redhat.com>
+test: tmt --help


### PR DESCRIPTION
This is a first approach to creating a manual workflow job for exporting tmt/testing-farm test runs to Polarion RHEL_EDGE project.