### PR TITLE
ci: run export test run to polarion workflow manually

### DIFF
--- a/.github/workflows/export-tc-to-polarion.yml
+++ b/.github/workflows/export-tc-to-polarion.yml
@@ -46,7 +46,7 @@ jobs:
 
   export-test-case:
     needs: pr-info
-    if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
+    if: ${{ needs.pr-info.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since export-tc-to-polarion.yml workflow is only for testing purposes, we will execute it manually (and not when the issue is a pull request).