### PR TITLE
test: remove fdo-container run file to trigger test properly

### DIFF
--- a/fdo-container.run
+++ b/fdo-container.run
@@ -1,1 +1,0 @@
-fdo-container


### PR DESCRIPTION
We need to remove this file in order to trigger fdo container test properly. If we merge fdo container PRs fdo-container.run file is merged into the repository and fdo container test fails. 