### PR TITLE
test: update fedora-43 ostree_ref from devel to stable

### DIFF
--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -77,7 +77,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-ostree-42-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-43")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/stable/${ARCH}/iot"
         OS_VARIANT="fedora-unknown"
         IMAGE_FILENAME="Fedora-IoT-ostree-43-${COMPOSE_ID}.${ARCH}.iso"
         ;;

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -87,7 +87,7 @@ case "${ID}-${VERSION_ID}" in
         RAW_IMAGE="Fedora-IoT-raw-42-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;
     "fedora-43")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/stable/${ARCH}/iot"
         OS_VARIANT="fedora-unknown"
         RAW_IMAGE="Fedora-IoT-raw-43-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;

--- a/iot-simplified-installer.sh
+++ b/iot-simplified-installer.sh
@@ -79,7 +79,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-provisioner-42-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-43")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/stable/${ARCH}/iot"
         OS_VARIANT="fedora-unknown"
         IMAGE_FILENAME="Fedora-IoT-provisioner-43-${COMPOSE_ID}.${ARCH}.iso"
         ;;


### PR DESCRIPTION
This is a fix for https://github.com/virt-s1/rhel-edge/issues/10903