### PR TITLE
ansible: update built in callback in the configuration file

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,8 +1,11 @@
 [defaults]
 timeout = 30
 # human-readable stdout/stderr results display
-stdout_callback = yaml
+stdout_callback = default
 
 [ssh_connection]
 scp_if_ssh=True
 pipelining=False
+
+[callback_default]
+result_format = yaml


### PR DESCRIPTION
CI has detected that all playbooks are failing due to current ansible configuration. 

`ansible.cfg` sets `stdout_callback = yaml`, which uses deprecated/removed community.general.yaml callback. The plugin no longer exists in ansible-core 2.18 and community.general 12.0.0.

The fix recommended by Cursor AI is to switch to the built‑in default callback and ask it to render YAML.

This is a suggested fix for https://github.com/virt-s1/rhel-edge/issues/10911