### PR TITLE
Fix virt-install failure due to missing GObject Introspection

### DIFF
--- a/iot-setup.sh
+++ b/iot-setup.sh
@@ -67,6 +67,7 @@ install_packages() {
         libvirt-daemon-kvm
         libvirt-daemon
         virt-install
+        gobject-introspection
         rpmdevtools
         createrepo_c
         lsof


### PR DESCRIPTION
Add `gobject-introspection` package to iot-setup.sh dependency list to resolve "Typelib file for namespace 'libxml2', version '2.0' not found" error when running virt-install.