### PR TITLE
fix: use gpt disklabel for UEFI compatibility

### DIFF
--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -122,7 +122,7 @@ modksiso() {
 text
 network --bootproto=dhcp --device=link --activate --onboot=on
 zerombr
-clearpart --all --initlabel --disklabel=msdos
+clearpart --all --initlabel --disklabel=gpt
 autopart --nohome --noswap --type=plain
 bootloader --append="console=tty0 console=ttyS0,115200n8"
 user --name=admin --groups=wheel --iscrypted --password=\$6\$1LgwKw9aOoAi/Zy9\$Pn3ErY1E8/yEanJ98evqKEW.DZp24HTuqXPJl6GYCm8uuobAmwxLv7rGCvTRZhxtcYdmC0.XnYRSR9Sh6de3p0


### PR DESCRIPTION
The test boots guests using UEFI, but the kickstart configuration was forcing an 'msdos' (MBR) disklabel. This caused a mismatch during installation, resulting in a BootloaderInstallationError when Anaconda attempted to write the bootloader configuration.

Fixes: https://github.com/virt-s1/rhel-edge/issues/10848