### PR TITLE
fix: increase memory to 16GB for edge and iot tests

### DIFF
--- a/ostree-ami-image.sh
+++ b/ostree-ami-image.sh
@@ -152,6 +152,12 @@ build_image() {
     sudo pkill -P ${WORKER_JOURNAL_PID}
     trap - EXIT
 
+    # Check disk usage after build
+    greenprint "💾 Disk usage after ${image_type} build"
+    df -h / /run 2>/dev/null || df -h
+    echo "Largest directories in /var:"
+    sudo du -sh /var/* 2>/dev/null | sort -h | tail -5 || true
+
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
         echo "Something went wrong with the compose. 😢"

--- a/ostree-simplified-installer.sh
+++ b/ostree-simplified-installer.sh
@@ -318,6 +318,12 @@ build_image() {
     sudo pkill -P ${WORKER_JOURNAL_PID}
     trap - EXIT
 
+    # Check disk usage after build
+    greenprint "💾 Disk usage after ${image_type} build"
+    df -h / /run 2>/dev/null || df -h
+    echo "Largest directories in /var:"
+    sudo du -sh /var/* 2>/dev/null | sort -h | tail -5 || true
+
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
         echo "Something went wrong with the compose. 😢"

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,12 @@ CI MACHINE SPECS
 EOF
 echo "CPU info"
 lscpu
+echo ""
+echo "Filesystem usage:"
+df -h /run /tmp / 2>/dev/null || df -h
+echo ""
+echo "Top space consumers in /run:"
+du -sh /run/* 2>/dev/null | sort -h | tail -10 || echo "No data in /run yet"
 echo -e "\033[0m"
 
 # Get OS data.

--- a/tmt/plans/edge-test.fmf
+++ b/tmt/plans/edge-test.fmf
@@ -10,7 +10,9 @@ provision:
       is-supported: true
     cpu:
       processors: ">= 4"
-    memory: ">= 8 GB"
+    memory: ">= 16 GB"
+    disk:
+      - size: ">= 60 GB"
 
 /edge-x86-commit:
   summary: Test edge commit

--- a/tmt/plans/iot-test.fmf
+++ b/tmt/plans/iot-test.fmf
@@ -10,7 +10,9 @@ provision:
       is-supported: true
     cpu:
       processors: ">= 2"
-    memory: ">= 6 GB"
+    memory: ">= 16 GB"
+    disk:
+      - size: ">= 60 GB"
 
 /iot-x86-installer:
   summary: Test fedora-iot x86_64 installer ISO image


### PR DESCRIPTION
This fixes the edge-x86-simplified-installer failure in ci testing, and makes the same change to the iot tests to prevent similar failures.

Error:
```
Nov 05 09:00:01 4115d70b-2a93-4762-939b-15fb6823969d osbuild-worker[15340]: time="2025-11-05T09:00:01Z" level=info msg="    gzip: /run/osbuild/tree/tmpvk919i5b/output/blobs/sha256/layer.tar.compressed: No space left on device" channel=local jobId=cd06ceb0-1dd5-4a53-b1fe-6f449f60802e
```


See:
https://github.com/virt-s1/rhel-edge/issues/10918