### PR TITLE
[WIP] ci: Use stable Fedora host for Rawhide testing

### DIFF
--- a/.github/workflows/fedora-iot-44.yml
+++ b/.github/workflows/fedora-iot-44.yml
@@ -6,6 +6,9 @@ on:
     types:
       - created
 
+env:
+  STABLE_COMPOSE: Fedora-43
+
 jobs:
   check-permissions:
     runs-on: ubuntu-latest
@@ -58,7 +61,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         id: run-test
         with:
-          compose: Fedora-Rawhide
+          compose: ${{ env.STABLE_COMPOSE }}
           arch: x86_64
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-permissions.outputs.repo_url }}
@@ -108,7 +111,7 @@ jobs:
   #       uses: sclorg/testing-farm-as-github-action@v3.1.2
   #       id: run-test
   #       with:
-  #         compose: Fedora-Rawhide
+  #         compose: ${{ env.STABLE_COMPOSE }}
   #         arch: aarch64
   #         api_key: ${{ secrets.TF_API_KEY }}
   #         git_url: ${{ needs.check-permissions.outputs.repo_url }}

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -6,6 +6,9 @@ on:
     types:
       - created
 
+env:
+  STABLE_COMPOSE: Fedora-43
+
 jobs:
   pr-info:
     if: ${{ github.event.issue.pull_request &&
@@ -57,7 +60,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
-          compose: Fedora-Rawhide-Nightly
+          compose: ${{ env.STABLE_COMPOSE }}
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -107,7 +110,7 @@ jobs:
   #     - name: Run the tests
   #       uses: sclorg/testing-farm-as-github-action@v3.1.2
   #       with:
-  #         compose: Fedora-Rawhide-Nightly
+  #         compose: ${{ env.STABLE_COMPOSE }}
   #         api_key: ${{ secrets.TF_API_KEY }}
   #         git_url: ${{ needs.pr-info.outputs.repo_url }}
   #         git_ref: ${{ needs.pr-info.outputs.ref }}


### PR DESCRIPTION
Use Fedora 43 (current stable) as the host OS when testing F44 IoT and Rawhide edge deliverables, instead of using Rawhide as the host.

Testing on an unstable Rawhide host leads to frequent breakage due to host-level issues (virtualization, kernel, etc.) that are unrelated to the edge/IoT deliverables being tested.

Changes:
 - fedora-iot-44.yml: Changed from Fedora-Rawhide to Fedora-43
 - fedora-rawhide.yml: Changed from Fedora-Rawhide-Nightly to Fedora-43
 - Added STABLE_COMPOSE env variable to both workflows for easy updates

When F44 becomes stable, only the STABLE_COMPOSE variable needs to be updated from Fedora-43 to Fedora-44.