### PR TITLE
tests: update ostree_ref built variable in f44

### DIFF
--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -77,7 +77,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-ostree-43-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-44")
-        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
+        OSTREE_REF="fedora/devel/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         IMAGE_FILENAME="Fedora-IoT-ostree-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -87,7 +87,7 @@ case "${ID}-${VERSION_ID}" in
         RAW_IMAGE="Fedora-IoT-raw-43-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;
     "fedora-44")
-        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
+        OSTREE_REF="fedora/devel/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         RAW_IMAGE="Fedora-IoT-raw-44-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;


### PR DESCRIPTION
We have seen failures in Fedora-IoT-44 such as [1]:

```
TASK [check ostree ref] ********************************************************
changed: [192.168.100.50] => {"changed": true, "cmd": "rpm-ostree status --json | jq -r '.deployments[0].origin'", "delta": "0:00:00.050135", "end": "2026-02-08 13:52:37.431363", "msg": "", "rc": 0, "start": "2026-02-08 13:52:37.381228", "stderr": "", "stderr_lines": [], "stdout": "fedora-iot:fedora/devel/x86_64/iot", "stdout_lines": ["fedora-iot:fedora/devel/x86_64/iot"]}

TASK [assert] ******************************************************************
[ERROR]: Task failed: Action failed: deployed ostree ref failed
Origin: /var/ARTIFACTS/work-iot-x86-installerht37m2hi/tmt/plans/iot-test/iot-x86-installer/discover/default-0/tests/check-ostree-iot.yaml:99:11

97     - name: check ostree ref deployed
98       block:
99         - assert:
             ^ column 11

fatal: [192.168.100.50]: FAILED! => {
    "assertion": "result_ref.stdout == ostree_ref",
    "changed": false,
    "evaluated_to": false,
    "msg": "deployed ostree ref failed"
}
```

[1] [iot-x86-installer error log](https://artifacts.osci.redhat.com/testing-farm/98795b4b-bb4a-4c0f-b4df-accc519785e9/work-iot-x86-installerht37m2hi/tmt/plans/iot-test/iot-x86-installer/execute/data/guest/default-0/tmt/tests/iot-test-1/output.txt)

Deployed ostree_ref has changed from `fedora-iot:fedora/rawhide/x86_64/iot` to `fedora-iot:fedora/devel/x86_64/iot`. Then  built and deployed ostree_ref assertion fails. We need to update ostree_ref in the corresponding scripts.