### PR TITLE
tests: fix OSTREE_REF for Fedora 44 in iot-simplified-installer

### DIFF
--- a/iot-simplified-installer.sh
+++ b/iot-simplified-installer.sh
@@ -79,7 +79,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-provisioner-43-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-44")
-        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
+        OSTREE_REF="fedora/devel/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         IMAGE_FILENAME="Fedora-IoT-provisioner-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;


### PR DESCRIPTION
This is a follow-up to pull request #11322, which updated `OSTREE_REF` from  `rawhide` to `devel` for Fedora 44 in `iot-installer.sh` and `iot-raw-image.sh`, but missed `iot-simplified-installer.sh`.

Although the test currently does not reach the ostree ref validation due to issue #11278, this needs to be fixed now so it does not become a problem once the blocking issue is resolved.