### PR TITLE
chores: fix fedora-iot-44 to not use rawhide compose

### DIFF
--- a/.github/workflows/fedora-iot-44.yml
+++ b/.github/workflows/fedora-iot-44.yml
@@ -58,7 +58,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         id: run-test
         with:
-          compose: Fedora-Rawhide
+          compose: Fedora-44
           arch: x86_64
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-permissions.outputs.repo_url }}

--- a/iot-bootc-image.sh
+++ b/iot-bootc-image.sh
@@ -85,7 +85,7 @@ case "${ID}-${VERSION_ID}" in
         OCI_ARCHIVE="Fedora-IoT-bootc-${ARCH}-43.${COMPOSE_ID}.ociarchive"
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-rawhide"
+        OS_VARIANT="fedora-unknown"
         OCI_ARCHIVE="Fedora-IoT-bootc-${ARCH}-44.${COMPOSE_ID}.ociarchive"
         ;;
     *)

--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -78,7 +78,7 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-44")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
-        OS_VARIANT="fedora-rawhide"
+        OS_VARIANT="fedora-unknown"
         IMAGE_FILENAME="Fedora-IoT-ostree-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     *)

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -88,7 +88,7 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-44")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
-        OS_VARIANT="fedora-rawhide"
+        OS_VARIANT="fedora-unknown"
         RAW_IMAGE="Fedora-IoT-raw-44-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;
     *)

--- a/iot-simplified-installer.sh
+++ b/iot-simplified-installer.sh
@@ -80,7 +80,7 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-44")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
-        OS_VARIANT="fedora-rawhide"
+        OS_VARIANT="fedora-unknown"
         IMAGE_FILENAME="Fedora-IoT-provisioner-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     *)


### PR DESCRIPTION
Fedora-IoT-44 has branched from the rolling Rawhide (now F45).

Since there are no Fedora-45 composes in testing-farm resources yet, let's fix the IoT scripts to keep testing F44 without referencing Rawhide.