### PR TITLE
chore: fix step name and punctuation in CS9 test workflow

### DIFF
--- a/.github/workflows/centos-stream-9.yml
+++ b/.github/workflows/centos-stream-9.yml
@@ -24,7 +24,7 @@ jobs:
         if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
         id: check_user_perm
         run: |
-          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}', allowed values: 'admin', 'write'"
           echo "allowed_user=true" >> $GITHUB_OUTPUT
 
       - name: Get information from pull request


### PR DESCRIPTION
### Changes
- fix preposition in step name ("Get information for pull request" → "Get information from pull request")
- add missing comma in permission check message