### PR TITLE
ci: remove continue-on-error from all test workflows

### DIFF
--- a/.github/workflows/centos-stream-9.yml
+++ b/.github/workflows/centos-stream-9.yml
@@ -45,7 +45,6 @@ jobs:
   edge-cs-9-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -97,7 +96,6 @@ jobs:
   edge-cs-9-arm:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/export-tc-to-polarion.yml
+++ b/.github/workflows/export-tc-to-polarion.yml
@@ -57,7 +57,6 @@ jobs:
   export-test-case:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/export-tmt-tests-to-polarion.yml
+++ b/.github/workflows/export-tmt-tests-to-polarion.yml
@@ -42,7 +42,6 @@ jobs:
   export-to-polarion:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/fdo-container.yml
+++ b/.github/workflows/fdo-container.yml
@@ -46,7 +46,6 @@ jobs:
   fdo-container-community:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request && endsWith(github.event.comment.body, '/test-fdo-container-community') }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     env:
       STATUS_NAME: fdo-container-community
@@ -77,7 +76,6 @@ jobs:
   fdo-container-official:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request && endsWith(github.event.comment.body, '/test-fdo-container-official') }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     env:
       STATUS_NAME: fdo-container-official

--- a/.github/workflows/fedora-43.yml
+++ b/.github/workflows/fedora-43.yml
@@ -44,7 +44,6 @@ jobs:
   iot-f43-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -94,7 +93,6 @@ jobs:
   # iot-rawhide-arm:
   #   needs: pr-info
   #   if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-  #   continue-on-error: true
   #   runs-on: ubuntu-latest
 
   #   steps:

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -44,7 +44,6 @@ jobs:
   iot-rawhide-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -94,7 +93,6 @@ jobs:
   # iot-rawhide-arm:
   #   needs: pr-info
   #   if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-  #   continue-on-error: true
   #   runs-on: ubuntu-latest
 
   #   steps:

--- a/.github/workflows/rhel-8-10.yml
+++ b/.github/workflows/rhel-8-10.yml
@@ -45,7 +45,6 @@ jobs:
   edge-rhel-810-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rhel-9-4.yaml
+++ b/.github/workflows/rhel-9-4.yaml
@@ -44,7 +44,6 @@ jobs:
   edge-rhel-94-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -95,7 +94,6 @@ jobs:
   edge-rhel-94-arm:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rhel-9-5.yml
+++ b/.github/workflows/rhel-9-5.yml
@@ -45,7 +45,6 @@ jobs:
   edge-rhel-95-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -96,7 +95,6 @@ jobs:
   edge-rhel-95-arm:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rhel-9-6.yml
+++ b/.github/workflows/rhel-9-6.yml
@@ -45,7 +45,6 @@ jobs:
   edge-rhel-96-x86:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -96,7 +95,6 @@ jobs:
   edge-rhel-96-arm:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### What
Remove `continue-on-error: true` from all workflow files.

### Why
With `continue-on-error: true`, the overall workflow status is green even when individual jobs fail, hiding real failures. Removing it ensures the workflow status reflects actual test results.

### Changes
- remove `continue-on-error: true` from 10 workflow files, including `#continue-on-error: true` to prevent reintroduction