### PR TITLE
fix: exclude systemd-remount-fs.service check from ostree playbook

### DIFF
--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -1515,8 +1515,13 @@
       when: test_custom_dirs_files_services == "true"
 
     # case: check no failed systemd units
+    # systemd-remount-fs.service is excluded because in OSTree/IoT deployments
+    # the filesystem layout (bind-mounts) is managed by ostree-remount.service
     - name: check systemd failed units
-      shell: systemctl --failed --no-legend --no-pager --plain | awk '{printf sep $1; sep=", "}'
+      shell: >
+        systemctl --failed --no-legend --no-pager --plain
+        | grep -v 'systemd-remount-fs\.service'
+        | awk '{printf sep $1; sep=", "}'
       register: result_failed_units
 
     - name: no systemd units should be in failed state


### PR DESCRIPTION
This is the same fix https://github.com/virt-s1/rhel-edge/pull/11625/changes/d70d63660776b889e10aeea8f37d975da948005b extended to ostree playbook.