### PR TITLE
fix: correct fallback log message to use 'rpm-ostree'

### DIFF
--- a/check-ostree-iot.yaml
+++ b/check-ostree-iot.yaml
@@ -377,7 +377,7 @@
           register: result_greenboot_log
         - assert:
             that:
-              - "'FALLBACK BOOT DETECTED! Default bootc deployment has been rolled back' in result_greenboot_log.stdout"
+              - "'FALLBACK BOOT DETECTED! Default rpm-ostree deployment has been rolled back' in result_greenboot_log.stdout"
             fail_msg: "Fallback log not found"
             success_msg: "Found fallback log"
       always:


### PR DESCRIPTION
### What
Replace `bootc` with `rpm-ostree` in the Greenboot fallback boot detection assertion.

### Why
@mcattamoredhat identified the root cause of the failure. The assertion string did not match the actual deployment log output, causing the fallback log check to fail.

Fixes #11709.