### PR TITLE
feat(ci): add retry attempt to Slack notification and fix test log link

### DIFF
--- a/.github/workflows/fedora-iot-44.yml
+++ b/.github/workflows/fedora-iot-44.yml
@@ -99,6 +99,14 @@ jobs:
             emoji=":x:"
           fi
 
+          if [[ "${{ github.run_attempt }}" -gt 1 ]]; then
+            attempt=" | Attempt #${{ github.run_attempt }}"
+          else
+            attempt=""
+          fi
+
+          text="$emoji *Fedora-44 | x86_64${attempt} | Compose-id: ${{ needs.pr-info.outputs.compose_id }} |* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|Test Log>"
+
           curl -X POST -H 'Content-type: application/json' --data '{
             "text": "Testing Farm Results for Fedora 44 IoT x86",
             "blocks": [
@@ -106,7 +114,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "'"$emoji"' *Fedora-44 | x86_64 | Compose-id: ${{ needs.pr-info.outputs.compose_id }} |* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Test Log>"
+                  "text": "'"$text"'"
                 }
               }
             ]


### PR DESCRIPTION
### What
Add retry attempt number to Slack notification and fix the test log link
to point to the specific run attempt instead of the latest one.

### Why
When a workflow is re-run, the Slack notification does not indicate which attempt
it is, and the test log link always points to the latest attempt, making it hard
to correlate results.