### PR TITLE
fix(test): use rawhide ostree ref for fedora-45 IoT tests

### DIFF
--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -82,7 +82,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-ostree-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-45")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         IMAGE_FILENAME="Fedora-IoT-ostree-45-${COMPOSE_ID}.${ARCH}.iso"
         ;;

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -92,7 +92,7 @@ case "${ID}-${VERSION_ID}" in
         RAW_IMAGE="Fedora-IoT-raw-44-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;
     "fedora-45")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         RAW_IMAGE="Fedora-IoT-raw-45-${COMPOSE_ID}.${ARCH}.raw.xz"
         ;;

--- a/iot-simplified-installer.sh
+++ b/iot-simplified-installer.sh
@@ -84,7 +84,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_FILENAME="Fedora-IoT-provisioner-44-${COMPOSE_ID}.${ARCH}.iso"
         ;;
     "fedora-45")
-        OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         IMAGE_FILENAME="Fedora-IoT-provisioner-45-${COMPOSE_ID}.${ARCH}.iso"
         ;;


### PR DESCRIPTION
Replace the fedora-45 ostree ref from `fedora/devel/<arch>/iot` to `fedora/rawhide/<arch>/iot` in the three IoT test scripts (installer, raw-image, simplified-installer).
The `devel` ref is used during early development cycles; the correct ref is `rawhide`.