### PR TITLE
fix(ci): use PAT in workflows to create PRs so lint workflow is triggered

### DIFF
--- a/.github/workflows/trigger-8.yml
+++ b/.github/workflows/trigger-8.yml
@@ -19,6 +19,15 @@ jobs:
     if: github.repository == 'virt-s1/rhel-edge'
     runs-on: container-runner
     steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
       - run: sudo dnf install -y git gh
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -162,9 +171,9 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "${{ needs.check-compose.outputs.rhel810_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/trigger-9.yml
+++ b/.github/workflows/trigger-9.yml
@@ -21,6 +21,15 @@ jobs:
     if: github.repository == 'virt-s1/rhel-edge'
     runs-on: container-runner
     steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
       - run: sudo dnf install -y git gh
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -388,9 +397,9 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "${{ needs.check-compose.outputs.rhel94_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
@@ -446,9 +455,9 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "${{ needs.check-compose.outputs.rhel95_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
@@ -504,9 +513,9 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "${{ needs.check-compose.outputs.rhel96_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/trigger-cs.yml
+++ b/.github/workflows/trigger-cs.yml
@@ -19,6 +19,15 @@ jobs:
     if: github.repository == 'virt-s1/rhel-edge'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Check CentOS Stream 9 compose
@@ -161,9 +170,9 @@ jobs:
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "${{ needs.check-compose.outputs.cs9_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/trigger-fdo-container.yml
+++ b/.github/workflows/trigger-fdo-container.yml
@@ -14,10 +14,24 @@ on:
 permissions: {}
 
 jobs:
+  verify-pat:
+    if: github.repository == 'virt-s1/rhel-edge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
   fdo-container-community:
     permissions:
       contents: write
       pull-requests: write
+    needs: [verify-pat]
     if: github.repository == 'virt-s1/rhel-edge' && github.event.schedule == '5 8 * * 0'
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +49,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "FDO community container test - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
@@ -59,6 +73,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    needs: [verify-pat]
     if: github.repository == 'virt-s1/rhel-edge' && github.event.schedule == '5 8 * * 4'
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +91,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "FDO official container test - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/trigger-fedora.yml
+++ b/.github/workflows/trigger-fedora.yml
@@ -19,6 +19,15 @@ jobs:
     if: github.repository == 'virt-s1/rhel-edge'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Check if fedora 43 compose is new
@@ -124,8 +133,9 @@ jobs:
 
       - name: Create Pull Request for fedora 43
         id: create-pr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+          token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose_id_43 }}"
           branch: cpr
           branch-suffix: random
@@ -134,8 +144,6 @@ jobs:
           commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose_id_43 }} to compose file"
           labels: |
             automated-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add a comment to trigger test workflow
         uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2

--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -20,6 +20,15 @@ jobs:
     if: github.repository == 'virt-s1/rhel-edge'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify PAT is configured
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "::error::secrets.PAT is not configured."
+            exit 1
+          fi
+        env:
+          PAT_TOKEN: ${{ secrets.PAT }}
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -104,8 +113,9 @@ jobs:
 
       - name: Create Pull Request for IoT 44
         id: create-pr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+          token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose-id-f44 }}"
           branch: cpr
           branch-suffix: random
@@ -114,8 +124,6 @@ jobs:
           commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose-id-f44 }} to compose file"
           labels: |
             automated-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add test comment to PR
         if: steps.create-pr.outputs.pull-request-number
@@ -142,8 +150,9 @@ jobs:
 
       - name: Create Pull Request for IoT 45
         id: create-pr
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+          token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose-id-f45 }}"
           branch: cpr
           branch-suffix: random
@@ -152,8 +161,6 @@ jobs:
           commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose-id-f45 }} to compose file"
           labels: |
             automated-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add test comment to PR
         if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
GitHub does not trigger pull_request events for PRs opened with GITHUB_TOKEN, so lint.yml was never triggered on automated PRs.

## Changes
- **All: `trigger-*.yml` workflows** (`trigger-8`, `trigger-9`, `trigger-cs`, `trigger-fedora`, `trigger-fdo-container`,  `trigger-iot`): switch `peter-evans/create-pull-request` from  `token: ${{ secrets.GITHUB_TOKEN }}` to `token: ${{ secrets.PAT }}`. PRs created via a PAT are attributed to a real user identity and  GitHub fires the `pull_request` event normally.
- **Style cleanup**: `trigger-iot.yml` and `trigger-fedora.yml` were  passing the token via the `env: GITHUB_TOKEN:` fallback form; both are updated to the canonical `token:` input inside `with:`.
- **Version alignment**: all `peter-evans/create-pull-request` pins upgraded from `v4` to `v7.0.5`, consistent with the version already used in `trigger-fdo-container.yml`.

## Notes
- `secrets.PAT` is already used in every workflow for the `create-or-update-comment` step, confirming the token is properly
  scoped.