### PR TITLE
ci: add -f flag to curl for HTTP error detection

### DIFF
--- a/.github/workflows/fedora-iot-44.yml
+++ b/.github/workflows/fedora-iot-44.yml
@@ -49,7 +49,7 @@ jobs:
             echo "is_compose_pr=true" >> $GITHUB_OUTPUT
           else
             # Fallback to latest from Koji
-            COMPOSE=$(curl -s https://kojipkgs.fedoraproject.org/compose/iot/ \
+            COMPOSE=$(curl -sf https://kojipkgs.fedoraproject.org/compose/iot/ \
               | grep -oP 'Fedora-IoT-44-\d+\.\d+' \
               | sort -t- -k4 -V \
               | tail -1)

--- a/.github/workflows/fedora-iot-45.yml
+++ b/.github/workflows/fedora-iot-45.yml
@@ -49,7 +49,7 @@ jobs:
             echo "is_compose_pr=true" >> $GITHUB_OUTPUT
           else
             # Fallback to latest from Koji
-            COMPOSE=$(curl -s https://kojipkgs.fedoraproject.org/compose/iot/ \
+            COMPOSE=$(curl -sf https://kojipkgs.fedoraproject.org/compose/iot/ \
               | grep -oP 'Fedora-IoT-45-\d+\.\d+' \
               | sort -t- -k4 -V \
               | tail -1)

--- a/.github/workflows/trigger-8.yml
+++ b/.github/workflows/trigger-8.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Check RHEL 8.10 compose
         id: check_compose_id_810
         run: |
-          curl -s ${COMPOSE_URL_810}/latest-RHEL-8.10.0/STATUS --output STATUS_810
+          curl -sf ${COMPOSE_URL_810}/latest-RHEL-8.10.0/STATUS --output STATUS_810
           STATUS_810=$(cat STATUS_810)
           if [[ "$STATUS_810" == "FINISHED" ]]; then
-              curl -s ${COMPOSE_URL_810}/latest-RHEL-8.10.0/COMPOSE_ID --output COMPOSE_ID_810
+              curl -sf ${COMPOSE_URL_810}/latest-RHEL-8.10.0/COMPOSE_ID --output COMPOSE_ID_810
               COMPOSE_ID_810=$(cat COMPOSE_ID_810)
               TESTED_COMPOSE_810=( $( cat compose/compose.810 ) )
               if [[ " ${TESTED_COMPOSE_810[*]} " =~ "$COMPOSE_ID_810" ]]; then
@@ -64,7 +64,7 @@ jobs:
               echo "osbuild_composer_version_810=$OSBUILD_COMPOSER_VERSION_810" >> $GITHUB_OUTPUT
               echo "composer_cli_version_810=$COMPOSER_CLI_VERSION_810" >> $GITHUB_OUTPUT
 
-              curl -s ${COMPOSE_URL_810}/ --output COMPOSES
+              curl -sf ${COMPOSE_URL_810}/ --output COMPOSES
               COMPOSES=$(cat -n COMPOSES)
               line=$(echo "${COMPOSES}" | grep ${COMPOSE_ID_810} | cut -b 1-7)
               old_line=$((line - 1))

--- a/.github/workflows/trigger-9.yml
+++ b/.github/workflows/trigger-9.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Check RHEL 9.4 compose
         id: check_compose_id_94
         run: |
-          curl -s ${COMPOSE_URL_94}/latest-RHEL-9.4.0/STATUS --output STATUS_94
+          curl -sf ${COMPOSE_URL_94}/latest-RHEL-9.4.0/STATUS --output STATUS_94
           STATUS_94=$(cat STATUS_94)
           if [[ "$STATUS_94" == "FINISHED" ]]; then
-              curl -s ${COMPOSE_URL_94}/latest-RHEL-9.4.0/COMPOSE_ID --output COMPOSE_ID_94
+              curl -sf ${COMPOSE_URL_94}/latest-RHEL-9.4.0/COMPOSE_ID --output COMPOSE_ID_94
               COMPOSE_ID_94=$(cat COMPOSE_ID_94)
               TESTED_COMPOSE_94=( $( cat compose/compose.94 ) )
               if [[ " ${TESTED_COMPOSE_94[*]} " =~ "$COMPOSE_ID_94" ]]; then
@@ -64,7 +64,7 @@ jobs:
               echo "osbuild_composer_version_94=$OSBUILD_COMPOSER_VERSION_94" >> $GITHUB_OUTPUT
               echo "composer_cli_version_94=$COMPOSER_CLI_VERSION_94" >> $GITHUB_OUTPUT
 
-              curl -s ${COMPOSE_URL_94}/ --output COMPOSES
+              curl -sf ${COMPOSE_URL_94}/ --output COMPOSES
               COMPOSES=$(cat -n COMPOSES)
               line=$(echo "${COMPOSES}" | grep ${COMPOSE_ID_94} | cut -b 1-7)
               old_line=$((line - 1))
@@ -142,10 +142,10 @@ jobs:
       - name: Check RHEL 9.5 compose
         id: check_compose_id_95
         run: |
-          curl -s ${COMPOSE_URL_95}/latest-RHEL-9.5.0/STATUS --output STATUS_95
+          curl -sf ${COMPOSE_URL_95}/latest-RHEL-9.5.0/STATUS --output STATUS_95
           STATUS_95=$(cat STATUS_95)
           if [[ "$STATUS_95" == "FINISHED" ]]; then
-              curl -s ${COMPOSE_URL_95}/latest-RHEL-9.5.0/COMPOSE_ID --output COMPOSE_ID_95
+              curl -sf ${COMPOSE_URL_95}/latest-RHEL-9.5.0/COMPOSE_ID --output COMPOSE_ID_95
               COMPOSE_ID_95=$(cat COMPOSE_ID_95)
               TESTED_COMPOSE_95=( $( cat compose/compose.95 ) )
               if [[ " ${TESTED_COMPOSE_95[*]} " =~ "$COMPOSE_ID_95" ]]; then
@@ -171,7 +171,7 @@ jobs:
               echo "osbuild_composer_version_95=$OSBUILD_COMPOSER_VERSION_95" >> $GITHUB_OUTPUT
               echo "composer_cli_version_95=$COMPOSER_CLI_VERSION_95" >> $GITHUB_OUTPUT
 
-              curl -s ${COMPOSE_URL_95}/ --output COMPOSES
+              curl -sf ${COMPOSE_URL_95}/ --output COMPOSES
               COMPOSES=$(cat -n COMPOSES)
               line=$(echo "${COMPOSES}" | grep ${COMPOSE_ID_95} | cut -b 1-7)
               old_line=$((line - 1))
@@ -249,10 +249,10 @@ jobs:
       - name: Check RHEL 9.6 compose
         id: check_compose_id_96
         run: |
-          curl -s ${COMPOSE_URL_96}/latest-RHEL-9.6.0/STATUS --output STATUS_96
+          curl -sf ${COMPOSE_URL_96}/latest-RHEL-9.6.0/STATUS --output STATUS_96
           STATUS_96=$(cat STATUS_96)
           if [[ "$STATUS_96" == "FINISHED" ]]; then
-              curl -s ${COMPOSE_URL_96}/latest-RHEL-9.6.0/COMPOSE_ID --output COMPOSE_ID_96
+              curl -sf ${COMPOSE_URL_96}/latest-RHEL-9.6.0/COMPOSE_ID --output COMPOSE_ID_96
               COMPOSE_ID_96=$(cat COMPOSE_ID_96)
               TESTED_COMPOSE_96=( $( cat compose/compose.96 ) )
               if [[ " ${TESTED_COMPOSE_96[*]} " =~ "$COMPOSE_ID_96" ]]; then
@@ -278,7 +278,7 @@ jobs:
               echo "osbuild_composer_version_96=$OSBUILD_COMPOSER_VERSION_96" >> $GITHUB_OUTPUT
               echo "composer_cli_version_96=$COMPOSER_CLI_VERSION_96" >> $GITHUB_OUTPUT
 
-              curl -s ${COMPOSE_URL_96}/ --output COMPOSES
+              curl -sf ${COMPOSE_URL_96}/ --output COMPOSES
               COMPOSES=$(cat -n COMPOSES)
               line=$(echo "${COMPOSES}" | grep ${COMPOSE_ID_96} | cut -b 1-7)
               old_line=$((line - 1))

--- a/.github/workflows/trigger-cs.yml
+++ b/.github/workflows/trigger-cs.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Check CentOS Stream 9 compose
         id: check_compose_id_cs9
         run: |
-          CURRENT_COMPOSE_CS9=$(curl -s "${COMPOSE_URL_CS9}/" | grep -ioE ">CentOS-Stream-9-.*/<" | tr -d '>/<' | tail -1)
-          curl -s ${COMPOSE_URL_CS9}/${CURRENT_COMPOSE_CS9}/STATUS --output STATUS_CS9
+          CURRENT_COMPOSE_CS9=$(curl -sf "${COMPOSE_URL_CS9}/" | grep -ioE ">CentOS-Stream-9-.*/<" | tr -d '>/<' | tail -1)
+          curl -sf ${COMPOSE_URL_CS9}/${CURRENT_COMPOSE_CS9}/STATUS --output STATUS_CS9
           STATUS_CS9=$(cat STATUS_CS9)
           if [[ "$STATUS_CS9" == "FINISHED" ]]; then
               COMPOSE_ID_CS9=$CURRENT_COMPOSE_CS9
@@ -62,7 +62,7 @@ jobs:
               echo "osbuild_composer_version_cs9=$OSBUILD_COMPOSER_VERSION_CS9" >> $GITHUB_OUTPUT
               echo "composer_cli_version_cs9=$COMPOSER_CLI_VERSION_CS9" >> $GITHUB_OUTPUT
 
-              curl -s ${COMPOSE_URL_CS9}/ --output COMPOSES
+              curl -sf ${COMPOSE_URL_CS9}/ --output COMPOSES
               COMPOSES=$(cat -n COMPOSES)
               line=$(echo "${COMPOSES}" | grep ${COMPOSE_ID_CS9} | cut -b 1-7)
               old_line=$((line - 1))

--- a/.github/workflows/trigger-fedora.yml
+++ b/.github/workflows/trigger-fedora.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if fedora 43 compose is new
         id: check_compose_id_43
         run: |
-          curl -s "${COMPOSE_URL_F43}/COMPOSE_ID" --output COMPOSE_ID
+          curl -sf "${COMPOSE_URL_F43}/COMPOSE_ID" --output COMPOSE_ID
           COMPOSE_ID=$(cat COMPOSE_ID)
           TESTED_COMPOSE=( $( cat compose/compose.f43 ) )
           if [[ " ${TESTED_COMPOSE[*]} " =~ "$COMPOSE_ID" ]]; then
@@ -55,7 +55,7 @@ jobs:
       - name: Check if fedora rawhide compose is new
         id: check_compose_id_rawhide
         run: |
-          curl -s "${COMPOSE_URL_RAWHIDE}/COMPOSE_ID" --output COMPOSE_ID
+          curl -sf "${COMPOSE_URL_RAWHIDE}/COMPOSE_ID" --output COMPOSE_ID
           COMPOSE_ID=$(cat COMPOSE_ID)
           TESTED_COMPOSE=( $( cat compose/compose.rawhide ) )
           if [[ " ${TESTED_COMPOSE[*]} " =~ "$COMPOSE_ID" ]]; then

--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Get compose ID for Fedora 44 IoT
         id: get-compose-f44
         run: |
-          status=$(curl -s ${COMPOSE_URL_44}/STATUS)
+          status=$(curl -sf ${COMPOSE_URL_44}/STATUS)
           if [ "$status" != "FINISHED" ]; then
             echo "Compose status: $status - no PR needed"
             echo "need-pr-f44=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          compose_id_f44=$(curl -s ${COMPOSE_URL_44}/COMPOSE_ID)
+          compose_id_f44=$(curl -sf ${COMPOSE_URL_44}/COMPOSE_ID)
           echo "compose-id-f44=$compose_id_f44" >> $GITHUB_OUTPUT
 
           if grep -q "$compose_id_f44" compose/compose.f44-iot; then
@@ -64,14 +64,14 @@ jobs:
       - name: Get compose ID for Fedora 45 IoT
         id: get-compose-f45
         run: |
-          status=$(curl -s ${COMPOSE_URL_45}/STATUS)
+          status=$(curl -sf ${COMPOSE_URL_45}/STATUS)
           if [ "$status" != "FINISHED" ]; then
             echo "Compose status: $status - no PR needed"
             echo "need-pr-f45=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          compose_id_f45=$(curl -s ${COMPOSE_URL_45}/COMPOSE_ID)
+          compose_id_f45=$(curl -sf ${COMPOSE_URL_45}/COMPOSE_ID)
           echo "compose-id-f45=$compose_id_f45" >> $GITHUB_OUTPUT
 
           if grep -q "$compose_id_f45" compose/compose.f45-iot; then


### PR DESCRIPTION
### What
Add `-f` flag to critical `curl` calls that fetch compose `STATUS` and `COMPOSE_ID`, and compose directory listings across all trigger and IoT workflows.

### Why
This PR fixes the issue #11877. 
`curl -s` silently returns the response body even on HTTP errors (404, 500), which can result in garbage data being processed. `curl -sf` returns a non-zero exit code on HTTP errors instead, preventing invalid data from propagating through the workflow.

Assisted-by: Claude (claude-opus-4-6)