### PR TITLE
fix(ci): prefix automated PR commit messages with chore: type

### DIFF
--- a/.github/workflows/trigger-8.yml
+++ b/.github/workflows/trigger-8.yml
@@ -174,7 +174,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "${{ needs.check-compose.outputs.rhel810_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: ${{ needs.check-compose.outputs.rhel810_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr

--- a/.github/workflows/trigger-9.yml
+++ b/.github/workflows/trigger-9.yml
@@ -400,7 +400,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "${{ needs.check-compose.outputs.rhel94_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: ${{ needs.check-compose.outputs.rhel94_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr
@@ -458,7 +458,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "${{ needs.check-compose.outputs.rhel95_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: ${{ needs.check-compose.outputs.rhel95_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr
@@ -516,7 +516,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "${{ needs.check-compose.outputs.rhel96_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: ${{ needs.check-compose.outputs.rhel96_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr

--- a/.github/workflows/trigger-cs.yml
+++ b/.github/workflows/trigger-cs.yml
@@ -173,7 +173,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "${{ needs.check-compose.outputs.cs9_compose }} - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: ${{ needs.check-compose.outputs.cs9_compose }} - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr

--- a/.github/workflows/trigger-fdo-container.yml
+++ b/.github/workflows/trigger-fdo-container.yml
@@ -50,7 +50,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "FDO community container test - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: FDO community container test - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr
@@ -92,7 +92,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ secrets.PAT }}
-          commit-message: "FDO official container test - ${{ steps.date.outputs.date }}"
+          commit-message: "chore: FDO official container test - ${{ steps.date.outputs.date }}"
           committer: cloudkitebot <henrywangxf1@gmail.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: cpr

--- a/.github/workflows/trigger-fedora.yml
+++ b/.github/workflows/trigger-fedora.yml
@@ -102,7 +102,7 @@ jobs:
 #           branch-suffix: random
 #           base: main
 #           body: "${{ needs.check-compose.outputs.compose_id_rawhide }}"
-#           commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose_id_rawhide }} to compose file"
+#           commit-message: "chore: add compose ID ${{ needs.check-compose.outputs.compose_id_rawhide }} to compose file"
 #           labels: |
 #             automated-pr
 #         env:
@@ -141,7 +141,7 @@ jobs:
           branch-suffix: random
           base: main
           body: "${{ needs.check-compose.outputs.compose_id_43 }}"
-          commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose_id_43 }} to compose file"
+          commit-message: "chore: add compose ID ${{ needs.check-compose.outputs.compose_id_43 }} to compose file"
           labels: |
             automated-pr
 

--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -121,7 +121,7 @@ jobs:
           branch-suffix: random
           base: main
           body: "${{ needs.check-compose.outputs.compose-id-f44 }}"
-          commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose-id-f44 }} to compose file"
+          commit-message: "chore: add compose ID ${{ needs.check-compose.outputs.compose-id-f44 }} to compose file"
           labels: |
             automated-pr
 
@@ -158,7 +158,7 @@ jobs:
           branch-suffix: random
           base: main
           body: "${{ needs.check-compose.outputs.compose-id-f45 }}"
-          commit-message: "Add compose ID ${{ needs.check-compose.outputs.compose-id-f45 }} to compose file"
+          commit-message: "chore: add compose ID ${{ needs.check-compose.outputs.compose-id-f45 }} to compose file"
           labels: |
             automated-pr
 


### PR DESCRIPTION
## Problem

All the trigger workflows have been generating automated commit messages without a [Conventional Commits](https://www.conventionalcommits.org/) `type:` prefix, causing the `commitlint` check to fail on every compose-detection PR with:
```
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
```

## Solution
Prefix every `commit-message:` field in all affected trigger workflows with `chore:`.
