### PR TITLE
fix(ci): add conventional commits prefix to dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Problem
Dependabot was generating commit messages without a type: prefix, causing `commitlint` to fail on every dependency update PR.

## Solution
Add a `commit-message.prefix: "chore"` entry to `.github/dependabot.yml` so that future dependabot PRs produce messages like:
`chore: bump actions/checkout from 3.6.0 to 6.0.3`