### PR TITLE
fix(ci): disable body and footer line length limits in commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Dependabot commit bodies contain long URLs (release notes, commit
+    // comparison links) that routinely exceed the 100-character default.
+    // These cannot be controlled via dependabot.yml, so the rules are
+    // disabled here while all other conventional-commit rules stay active.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
+  },
+};


### PR DESCRIPTION
Dependabot commit bodies contain long URLs that cannot be controlled via dependabot.yml, causing body-max-line-length violations. All other conventional commit rules remain enforced.