### PR TITLE
chore: bump peter-evans/create-pull-request to v8.1.1

### DIFF
--- a/.github/workflows/clear-compose-file.yml
+++ b/.github/workflows/clear-compose-file.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Clear compose file - ${{ steps.date.outputs.date }}"

--- a/.github/workflows/export-tmt-tests-to-polarion.yml
+++ b/.github/workflows/export-tmt-tests-to-polarion.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Create Pull Request with TMT IDs
         if: ${{ !inputs.dry_run }}
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: append Polarion identifiers to tmt test cases"

--- a/.github/workflows/trigger-8.yml
+++ b/.github/workflows/trigger-8.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: ${{ needs.check-compose.outputs.rhel810_compose }} - ${{ steps.date.outputs.date }}"

--- a/.github/workflows/trigger-9.yml
+++ b/.github/workflows/trigger-9.yml
@@ -397,7 +397,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: ${{ needs.check-compose.outputs.rhel94_compose }} - ${{ steps.date.outputs.date }}"
@@ -455,7 +455,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: ${{ needs.check-compose.outputs.rhel95_compose }} - ${{ steps.date.outputs.date }}"
@@ -513,7 +513,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: ${{ needs.check-compose.outputs.rhel96_compose }} - ${{ steps.date.outputs.date }}"

--- a/.github/workflows/trigger-cs.yml
+++ b/.github/workflows/trigger-cs.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: ${{ needs.check-compose.outputs.cs9_compose }} - ${{ steps.date.outputs.date }}"

--- a/.github/workflows/trigger-fdo-container.yml
+++ b/.github/workflows/trigger-fdo-container.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: FDO community container test - ${{ steps.date.outputs.date }}"
@@ -89,7 +89,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: FDO official container test - ${{ steps.date.outputs.date }}"

--- a/.github/workflows/trigger-fedora.yml
+++ b/.github/workflows/trigger-fedora.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Create Pull Request for fedora 43
         id: create-pr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose_id_43 }}"

--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Create Pull Request for IoT 44
         id: create-pr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose-id-f44 }}"
@@ -150,7 +150,7 @@ jobs:
 
       - name: Create Pull Request for IoT 45
         id: create-pr
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           title: "${{ needs.check-compose.outputs.compose-id-f45 }}"


### PR DESCRIPTION
## Problem
After merging #12017 (actions/checkout v3.6.0 → v6.0.3), all `trigger-*` compose-detection workflows stopped creating PRs.


## Fix
Upgrade `peter-evans/create-pull-request` from v7 to v8.1.1 (`5f6978faf089d4d20b00c7766989d076bb2fc7f1`) across all affected workflows.