### PR TITLE
fix(commitlint): disable subject-case rule for auto-generated compose PRs

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,11 +1,13 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    // Dependabot commit bodies contain long URLs (release notes, commit
-    // comparison links) that routinely exceed the 100-character default.
-    // These cannot be controlled via dependabot.yml, so the rules are
-    // disabled here while all other conventional-commit rules stay active.
+    // Auto-generated content from trigger workflows (compose IDs such as
+    // RHEL-9.4.0-updates-..., CentOS-Stream-9-..., FDO) and Dependabot
+    // (long URLs in bodies/footers) cannot be controlled to comply with
+    // these rules, so they are disabled. All remaining conventional-commit
+    // rules stay active.
     'body-max-line-length': [0],
     'footer-max-line-length': [0],
+    'subject-case': [0],
   },
 };


### PR DESCRIPTION
## Problem

Auto-generated compose trigger PRs are failing commitlint with:

` subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]`

The commit subjects produced by the trigger workflows contain fixed product identifiers (e.g. `RHEL-9.4.0-updates-20260608.1`, `CentOS-Stream-9-...`, `Fedora-IoT-44-...`, `FDO`) whose casing cannot be changed without breaking
traceability.

Affected workflows: trigger-9.yml, trigger-8.yml, trigger-cs.yml, trigger-fdo-container.yml, trigger-iot.yml, trigger-fedora.yml.

## Fix

Disable the `subject-case` rule in `commitlint.config.js`, following the same precedent as `body-max-line-length` and `footer-max-line-length` which were disabled for the same reason (auto-generated content that cannot be controlled).

All other conventional-commit rules remain active.

Assisted-by: Claude Sonnet 4.6