### PR TITLE
fix(ci): skip Slack for non-compose PRs

### DIFF
--- a/.github/workflows/centos-stream-9.yml
+++ b/.github/workflows/centos-stream-9.yml
@@ -79,7 +79,7 @@ jobs:
           timeout: 180
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'CentOS-Stream-9-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"
@@ -133,7 +133,7 @@ jobs:
           timeout: 180
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'CentOS-Stream-9-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/fedora-43.yml
+++ b/.github/workflows/fedora-43.yml
@@ -76,7 +76,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'Fedora-43-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -76,7 +76,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'Fedora-Rawhide-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/rhel-8-10.yml
+++ b/.github/workflows/rhel-8-10.yml
@@ -78,7 +78,7 @@ jobs:
           variables: "ARCH=x86_64"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-8.10.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/rhel-9-4.yaml
+++ b/.github/workflows/rhel-9-4.yaml
@@ -77,7 +77,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.4.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"
@@ -130,7 +130,7 @@ jobs:
           variables: "ARCH=aarch64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.4.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/rhel-9-5.yml
+++ b/.github/workflows/rhel-9-5.yml
@@ -78,7 +78,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.5.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"
@@ -131,7 +131,7 @@ jobs:
           variables: "ARCH=aarch64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.5.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"

--- a/.github/workflows/rhel-9-6.yml
+++ b/.github/workflows/rhel-9-6.yml
@@ -78,7 +78,7 @@ jobs:
           variables: "ARCH=x86_64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.6.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"
@@ -131,7 +131,7 @@ jobs:
           variables: "ARCH=aarch64;AWS_DEFAULT_REGION=us-east-1;GOVC_INSECURE=1"
 
       - name: Send test results to Slack via webhook
-        if: always()
+        if: ${{ always() && startsWith(needs.pr-info.outputs.compose_id, 'RHEL-9.6.0-') }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             emoji=":white_check_mark:"


### PR DESCRIPTION
### What
Skip Slack notifications when tests are triggered on non-compose PRs by gating the Slack step on the PR title matching a compose ID prefix.

### Why
When running tests on non-compose PRs (for example, code changes) via comment triggers like `/test-rhel-9-6`, Slack messages were sent unconditionally, adding noise to the channel. Follow-up to PR #11716 and PR #11622.

Assisted-by: Claude (claude-opus-4-6)