### PR TITLE
style: standardize set flags order to -euox pipefail

### DIFF
--- a/ostree.sh
+++ b/ostree.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # --------------------------------------------------------------------------
 # NOTE: This script runs on a host VM (provisioned by Testing Farm)

--- a/tools/arm-commit.sh
+++ b/tools/arm-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-ignition.sh
+++ b/tools/arm-ignition.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-installer.sh
+++ b/tools/arm-installer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-minimal.sh
+++ b/tools/arm-minimal.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-raw.sh
+++ b/tools/arm-raw.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-rebase.sh
+++ b/tools/arm-rebase.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/arm-simplified.sh
+++ b/tools/arm-simplified.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1

--- a/tools/edge-raw.sh
+++ b/tools/edge-raw.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euox pipefail
 
 # Get TEST_OS from $1
 TEST_OS=$1


### PR DESCRIPTION
Standardize `set -exuo pipefail` to `set -euox pipefail` to match the convention used in the rest of the codebase.

This PR fixes the issue https://github.com/virt-s1/rhel-edge/issues/11910.

Assisted-by: Claude (claude-opus-4-6)