### PR TITLE
fix: simplify waiting for greenboot rollback completion

### DIFF
--- a/check-ostree-iot.yaml
+++ b/check-ostree-iot.yaml
@@ -303,36 +303,13 @@
           delegate_to: 127.0.0.1
           ignore_errors: yes
 
-        - name: wait for connection to become reachable/usable
-          wait_for_connection:
-            delay: 60
-            timeout: 1200
-            connect_timeout: 15
-            sleep: 15
-          register: reconnect_result
-
-        - debug:
-            msg: "Connection reachable after {{ reconnect_result.elapsed }} seconds."
-
-        - name: waits until instance is reachable
-          wait_for:
-            host: "{{ ansible_facts['all_ipv4_addresses'][0] }}"
-            port: 22
-            search_regex: OpenSSH
-            delay: 10
-            timeout: 600
+        - name: wait for greenboot rollback to complete
+          command: journalctl -b -0 -u greenboot-healthcheck.service --grep 'FALLBACK BOOT DETECTED' --quiet
           register: result_rollback
-          until: result_rollback is success
+          until: result_rollback.rc == 0
           retries: 30
           delay: 20
-          ignore_errors: yes
-
-        - name: verify system is reachable with ping
-          ping:
-          register: ping_result
-          until: ping_result is success
-          retries: 5
-          delay: 5
+          ignore_unreachable: yes
           ignore_errors: yes
 
         - assert:


### PR DESCRIPTION
### What
Replace multi-step reachability checks with a single `journalctl`-based check for greenboot rollback completion.

### Why
After a greenboot rollback reboot, the host becomes temporarily unreachable. The original approach used sequential `wait_for_connection`, `wait_for`, and `ping` tasks, but `wait_for` requires an SSH connection to execute — if the host is unreachable at that moment, the task fails with `UNREACHABLE` before its timeout even starts.

This PR uses `ignore_unreachable: yes` to handle transient connection failures during reboot and checks for `FALLBACK BOOT DETECTED` in the greenboot journal, which confirms the rollback actually completed rather than just verifying host reachability.

Follow-up to PR #11625.