### PR TITLE
fix: prevent early termination of greenboot rollback loop

### DIFF
--- a/check-ostree-iot.yaml
+++ b/check-ostree-iot.yaml
@@ -306,10 +306,9 @@
         - name: wait for greenboot rollback to complete
           command: journalctl -b -0 -u greenboot-healthcheck.service --grep 'FALLBACK BOOT DETECTED' --quiet
           register: result_rollback
-          until: result_rollback.rc == 0
+          until: result_rollback.rc is defined and result_rollback.rc == 0
           retries: 30
           delay: 20
-          ignore_unreachable: yes
           ignore_errors: yes
 
         - assert:


### PR DESCRIPTION
Assisted-by: Claude (claude-opus-4-6)