### PR TITLE
fix(iot): wait for greenboot-healthcheck to finish before asserting state

### DIFF
--- a/check-ostree-iot.yaml
+++ b/check-ostree-iot.yaml
@@ -265,14 +265,18 @@
       # case: check greenboot* service status
     - name: greenboot healthcheck service should be active
       block:
-        - name: greenboot healthcheck service should be active
+        - name: wait for greenboot healthcheck service to finish
           command: systemctl is-active greenboot-healthcheck.service
           register: result_greenboot_active
+          retries: 24
+          delay: 5
+          until: result_greenboot_active.stdout != "activating"
+          failed_when: false
 
         - assert:
             that:
               - result_greenboot_active.stdout == "active"
-            fail_msg: "greenboot healthcheck service is not active"
+            fail_msg: "greenboot healthcheck service is not active (state: {{ result_greenboot_active.stdout }})"
             success_msg: "greenboot healthcheck service is active"
       always:
         - set_fact:


### PR DESCRIPTION
The Ansible task checked systemctl is-active once with no retry. If a slow health check script (e.g. 01_update_platforms_check.sh) was still running, the service reported "activating" and the test failed with a false negative.

Add a retry loop (up to 2 min) that waits for the service to leave "activating" state before asserting.