### PR TITLE
fix(iot): disable virtual TPM on VMs that don't need it

### DIFF
--- a/iot-bootc-image.sh
+++ b/iot-bootc-image.sh
@@ -212,6 +212,7 @@ sudo virt-install  --name="iot-bootc-image-${TEST_UUID}"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot "uefi" \
+                   --tpm none \
                    --nographics \
                    --noautoconsole \
                    --wait=-1 \

--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -209,6 +209,7 @@ virt-install --name="iot-${TEST_UUID}" \
     --os-variant "${OS_VARIANT}" \
     --cdrom "/var/lib/libvirt/images/${IMAGE_FILENAME}" \
     --boot uefi \
+    --tpm none \
     --nographics \
     --noautoconsole \
     --wait=-1 \

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -230,6 +230,7 @@ sudo virt-install  --name="iot-${TEST_UUID}" \
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot uefi \
+                   --tpm none \
                    --nographics \
                    --noautoconsole \
                    --wait=-1 \


### PR DESCRIPTION
IoT tests don't exercise TPM or measured-boot functionality, but virt-install auto-adds a vTPM for UEFI boots on modern os-variants. A Fedora 44 SELinux userspace regression (selinux-policy 45.8-1) breaks swtpm-selinux's CIL policy compilation (RHBZ#2511086), leaving /usr/bin/swtpm mislabeled and unable to exec under libvirt. This fails every UEFI VM boot in CI.

Since the vTPM was never needed, explicitly disable it instead of waiting for the swtpm fix to reach stable repos.

iot-simplified-installer.sh is left as-is because it tests encrypted root (coreos.inst.crypt_root=1) which requires TPM emulation.

See also: fedora-iot/greenboot-rs#193