### PR TITLE
ci: add Fedora IoT 46 support

### DIFF
--- a/.github/workflows/fedora-iot-46.yml
+++ b/.github/workflows/fedora-iot-46.yml
@@ -1,0 +1,178 @@
+---
+name: Run Fedora 46 IoT test
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: {}
+
+jobs:
+  pr-info:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request &&
+            (endsWith(github.event.comment.body, '/test-f46-iot')) }}
+    steps:
+      - name: Query author repository permissions
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
+        id: user_permission
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if user does have correct permissions
+        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
+        id: check_user_perm
+        run: |
+          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+          echo "allowed_user=true" >> $GITHUB_OUTPUT
+
+      - name: Get information for pull request
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
+        id: pr-api
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine compose ID
+        id: determine_compose
+        run: |
+          # Try PR title
+          COMPOSE="${{ fromJson(steps.pr-api.outputs.data).title }}"
+
+          if [[ "${COMPOSE}" =~ ^Fedora-IoT-46- ]]; then
+            echo "is_compose_pr=true" >> $GITHUB_OUTPUT
+          else
+            # Fallback to latest from Koji
+            COMPOSE=$(curl -sf https://kojipkgs.fedoraproject.org/compose/iot/ \
+              | grep -oP 'Fedora-IoT-46-\d+\.\d+' \
+              | sort -t- -k4 -V \
+              | tail -1)
+            echo "is_compose_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "compose_id=${COMPOSE}" >> $GITHUB_OUTPUT
+
+    outputs:
+      allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
+      compose_id: ${{ steps.determine_compose.outputs.compose_id }}
+      is_compose_pr: ${{ steps.determine_compose.outputs.is_compose_pr }}
+      sha: ${{ fromJson(steps.pr-api.outputs.data).head.sha }}
+      ref: ${{ fromJson(steps.pr-api.outputs.data).head.ref }}
+      repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
+
+  iot-46-x86:
+    permissions:
+      contents: read
+      statuses: write
+    needs: pr-info
+    if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.pr-info.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+        id: run-test
+        with:
+          compose: Fedora-44
+          arch: x86_64
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.pr-info.outputs.repo_url }}
+          git_ref: ${{ needs.pr-info.outputs.ref }}
+          update_pull_request_status: true
+          tmt_context: "arch=x86_64;distro=fedora-44"
+          pull_request_status_name: "iot-f46-x86"
+          tmt_plan_regex: iot-x86
+          tf_scope: private
+          variables: "COMPOSE=${{ needs.pr-info.outputs.compose_id }}"
+
+      - name: Send test results to Slack via webhook
+        if: ${{ always() && needs.pr-info.outputs.is_compose_pr == 'true' }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            emoji=":white_check_mark:"
+          else
+            emoji=":x:"
+          fi
+
+          if [[ "${{ github.run_attempt }}" -gt 1 ]]; then
+            attempt=" | Attempt #${{ github.run_attempt }}"
+          else
+            attempt=""
+          fi
+
+          text="$emoji *Fedora-46 | x86_64${attempt} | Compose-id: ${{ needs.pr-info.outputs.compose_id }} |* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|Test Log>"
+
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": "Testing Farm Results for Fedora 46 IoT x86",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "'"$text"'"
+                }
+              }
+            ]
+          }' ${{ secrets.SLACK_WEBHOOK_URL_FEDORA_IOT_CI }}
+
+  # iot-46-aarch64:
+  #   needs: pr-info
+  #   if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request }}
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  #       with:
+  #         ref: ${{ needs.pr-info.outputs.sha }}
+  #         fetch-depth: 0
+
+  #     - name: Run the tests
+  #       uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+  #       id: run-test
+  #       with:
+  #         compose: Fedora-44
+  #         arch: aarch64
+  #         api_key: ${{ secrets.TF_API_KEY }}
+  #         git_url: ${{ needs.pr-info.outputs.repo_url }}
+  #         git_ref: ${{ needs.pr-info.outputs.ref }}
+  #         update_pull_request_status: true
+  #         tmt_context: "arch=aarch64;distro=fedora-44"
+  #         pull_request_status_name: "iot-f46-aarch64"
+  #         tmt_plan_regex: iot-aarch64
+  #         tf_scope: private
+  #         variables: "COMPOSE=${{ needs.pr-info.outputs.compose_id }}"
+
+  #     - name: Send test results to Slack via webhook
+  #       if: always()
+  #       run: |
+  #         if [ "${{ job.status }}" = "success" ]; then
+  #           emoji=":white_check_mark:"
+  #         else
+  #           emoji=":x:"
+  #         fi
+
+  #         curl -X POST -H 'Content-type: application/json' --data '{
+  #           "text": "Testing Farm Results for Fedora 46 IoT aarch64",
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": "'"$emoji"' *Fedora-46 | aarch64 | Compose-id: ${{ needs.pr-info.outputs.compose_id }} |* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Test Log>"
+  #               }
+  #             }
+  #           ]
+  #         }' ${{ secrets.SLACK_WEBHOOK_URL_FEDORA_IOT_CI }}

--- a/.github/workflows/trigger-iot.yml
+++ b/.github/workflows/trigger-iot.yml
@@ -11,6 +11,7 @@ permissions: {}
 env:
   COMPOSE_URL_44: https://kojipkgs.fedoraproject.org/compose/iot/latest-Fedora-IoT-44
   COMPOSE_URL_45: https://kojipkgs.fedoraproject.org/compose/iot/latest-Fedora-IoT-45
+  COMPOSE_URL_46: https://kojipkgs.fedoraproject.org/compose/iot/latest-Fedora-IoT-46
 
 jobs:
   check-compose:
@@ -90,11 +91,42 @@ jobs:
             echo "need-pr-f45=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get compose ID for Fedora 46 IoT
+        id: get-compose-f46
+        run: |
+          status=$(curl -sf ${COMPOSE_URL_46}/STATUS)
+          if [ "$status" != "FINISHED" ]; then
+            echo "Compose status: $status - no PR needed"
+            echo "need-pr-f46=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          compose_id_f46=$(curl -sf ${COMPOSE_URL_46}/COMPOSE_ID)
+          echo "compose-id-f46=$compose_id_f46" >> $GITHUB_OUTPUT
+
+          if grep -q "$compose_id_f46" compose/compose.f46-iot; then
+            echo "This compose has been tested already"
+            echo "need-pr-f46=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
+          if echo "$response" | grep -q "$compose_id_f46"; then
+            echo "This compose is being tested now, skip it."
+            echo "need-pr-f46=false" >> $GITHUB_OUTPUT
+          else
+            echo "This is a new compose, will trigger test soon."
+            echo "need-pr-f46=true" >> $GITHUB_OUTPUT
+          fi
+
     outputs:
       need-pr-f44: ${{ steps.get-compose-f44.outputs.need-pr-f44 }}
       compose-id-f44: ${{ steps.get-compose-f44.outputs.compose-id-f44 }}
       need-pr-f45: ${{ steps.get-compose-f45.outputs.need-pr-f45 }}
       compose-id-f45: ${{ steps.get-compose-f45.outputs.compose-id-f45 }}
+      need-pr-f46: ${{ steps.get-compose-f46.outputs.need-pr-f46 }}
+      compose-id-f46: ${{ steps.get-compose-f46.outputs.compose-id-f46 }}
 
   create-pr-f44:
     permissions:
@@ -169,3 +201,40 @@ jobs:
           token: ${{ secrets.PAT }}
           issue-number: ${{ steps.create-pr.outputs.pull-request-number }}
           body: /test-f45-iot
+
+  create-pr-f46:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: check-compose
+    if: needs.check-compose.outputs.need-pr-f46 == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Update compose_id_46 file
+        run: |
+          echo "${{ needs.check-compose.outputs.compose-id-f46 }}" >> compose/compose.f46-iot
+
+      - name: Create Pull Request for IoT 46
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.PAT }}
+          title: "${{ needs.check-compose.outputs.compose-id-f46 }}"
+          branch: cpr
+          branch-suffix: random
+          base: main
+          body: "${{ needs.check-compose.outputs.compose-id-f46 }}"
+          commit-message: "chore: add compose ID ${{ needs.check-compose.outputs.compose-id-f46 }} to compose file"
+          labels: |
+            automated-pr
+
+      - name: Add test comment to PR
+        if: steps.create-pr.outputs.pull-request-number
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          issue-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          body: /test-f46-iot

--- a/CI.md
+++ b/CI.md
@@ -34,6 +34,7 @@ Create a pull request and add a comment according to the following table:
 | `/test-cs9` | All CentOS Stream 9 Edge tests |
 | `/test-f44-iot` | Fedora IoT 44 tests |
 | `/test-f45-iot` | Fedora IoT 45 tests |
+| `/test-f46-iot` | Fedora IoT 46 tests |
 
 ## `rhel-edge` repository CI
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To run tests on ARM, a bare metal ARM server is required.
 - CentOS Stream 9
 - Fedora IoT 44
 - Fedora IoT 45
+- Fedora IoT 46
 
 ### Test configuration
 

--- a/iot-bootc-image.sh
+++ b/iot-bootc-image.sh
@@ -87,6 +87,9 @@ case "${IOT_VERSION}" in
         OS_VARIANT="fedora-unknown"
         ;;
     "45")
+        OS_VARIANT="fedora-unknown"
+        ;;
+    "46")
         OS_VARIANT="fedora-rawhide"
         ;;
     *)

--- a/iot-installer.sh
+++ b/iot-installer.sh
@@ -81,6 +81,10 @@ case "${IOT_VERSION}" in
         ;;
     "45")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OS_VARIANT="fedora-unknown"
+        ;;
+    "46")
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         ;;
     *)

--- a/iot-raw-image.sh
+++ b/iot-raw-image.sh
@@ -90,6 +90,10 @@ case "${IOT_VERSION}" in
         ;;
     "45")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OS_VARIANT="fedora-unknown"
+        ;;
+    "46")
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         ;;
     *)

--- a/iot-simplified-installer.sh
+++ b/iot-simplified-installer.sh
@@ -82,6 +82,10 @@ case "${IOT_VERSION}" in
         ;;
     "45")
         OSTREE_REF="fedora/devel/${ARCH}/iot"
+        OS_VARIANT="fedora-unknown"
+        ;;
+    "46")
+        OSTREE_REF="fedora/rawhide/${ARCH}/iot"
         OS_VARIANT="fedora-rawhide"
         ;;
     *)

--- a/iot-testing-workflow-overview.md
+++ b/iot-testing-workflow-overview.md
@@ -12,7 +12,8 @@ Fedora IoT tests **do not build images** — they download pre-built compose art
 | Stream | Status | Testing Farm compose | OSTree ref |
 |--------|--------|----------------------|------------|
 | Fedora IoT 44 (F44) | Stable | `Fedora-44` | `fedora/stable/${ARCH}/iot` |
-| Fedora IoT 45 (F45) | Active | `Fedora-44` | `fedora/rawhide/${ARCH}/iot` |
+| Fedora IoT 45 (F45) | Devel | `Fedora-44` | `fedora/devel/${ARCH}/iot` |
+| Fedora IoT 46 (F46) | Rawhide | `Fedora-44` | `fedora/rawhide/${ARCH}/iot` |
 
 ## Data flow
 
@@ -26,8 +27,9 @@ Daily 13:00 UTC
 │    - Fetch latest compose from kojipkgs.fedoraproject.org           │
 │    - Check F44: compare with compose/compose.f44-iot                │
 │    - Check F45: compare with compose/compose.f45-iot                │
+│    - Check F46: compare with compose/compose.f46-iot                │
 │    - If new compose found, create PR and add trigger comment        │
-│      F44 → /test-f44-iot   F45 → /test-f45-iot                      │
+│      F44 → /test-f44-iot   F45 → /test-f45-iot   F46 → /test-f46-iot│
 └─────────────────────────────────────────────────────────────────────┘
                      │
                      │ PR created with compose ID as title
@@ -36,6 +38,7 @@ Daily 13:00 UTC
 │ 2. TRIGGER TESTS                                                    │
 │    F44: .github/workflows/fedora-iot-44.yml  (/test-f44-iot)        │
 │    F45: .github/workflows/fedora-iot-45.yml  (/test-f45-iot)        │
+│    F46: .github/workflows/fedora-iot-46.yml  (/test-f46-iot)        │
 │    - Call Testing Farm                                              │
 └─────────────────────────────────────────────────────────────────────┘
                      │
@@ -79,6 +82,7 @@ Daily 13:00 UTC
 │ 6. REPORT RESULTS                                                   │
 │    F44: fedora-iot-44.yml → PR check: iot-f44-x86 ✅/❌             │
 │    F45: fedora-iot-45.yml → PR check: iot-f45-x86 ✅/❌             │
+│    F46: fedora-iot-46.yml → PR check: iot-f46-x86 ✅/❌             │
 │    - Sends test results to Slack                                    │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -92,30 +96,32 @@ trigger-iot.yml
     │
     ├─ Reads: compose/compose.f44-iot           [list of tested F44 composes]
     ├─ Reads: compose/compose.f45-iot           [list of tested F45 composes]
+    ├─ Reads: compose/compose.f46-iot           [list of tested F46 composes]
     ├─ Fetches: kojipkgs.fedoraproject.org      [compose server]
     │
     └─ Creates PR per stream
          F44 - Title: Fedora-IoT-44-YYYYMMDD.N  Comment: /test-f44-iot
          F45 - Title: Fedora-IoT-45-YYYYMMDD.N  Comment: /test-f45-iot
+         F46 - Title: Fedora-IoT-46-YYYYMMDD.N  Comment: /test-f46-iot
 ```
 
 ### 2. PR comment → Testing Farm
 
 ```
-fedora-iot-44.yml (triggered by /test-f44-iot)        fedora-iot-45.yml (triggered by /test-f45-iot)
-    │                                                       │
-    ├─ Job: check-permissions                               ├─ Job: check-permissions
-    │    ├─ Checks: User permissions via GitHub API         │    ├─ Checks: User permissions via GitHub API
-    │    └─ Extracts from PR                                │    └─ Extracts from PR
-    │         - sha (commit to test)                        │         - sha (commit to test)
-    │         - ref (branch name)                           │         - ref (branch name)
-    │         - compose_id (from PR title)                  │         - compose_id (from PR title)
-    │                                                       │
-    └─ Job: iot-44-x86                                      └─ Job: iot-45-x86
-         └─ Testing Farm                                         └─ Testing Farm
-              - compose: Fedora-44                                    - compose: Fedora-44
-              - tmt_context: "arch=x86_64;distro=fedora-44"            - tmt_context: "arch=x86_64;distro=fedora-44"
-              - tmt_plan_regex: iot-x86                               - tmt_plan_regex: iot-x86
+fedora-iot-{44,45,46}.yml (triggered by /test-f{44,45,46}-iot)
+    │
+    ├─ Job: pr-info
+    │    ├─ Checks: User permissions via GitHub API
+    │    └─ Extracts from PR
+    │         - sha (commit to test)
+    │         - ref (branch name)
+    │         - compose_id (from PR title or Koji fallback)
+    │
+    └─ Job: iot-{44,45,46}-x86
+         └─ Testing Farm
+              - compose: Fedora-44
+              - tmt_context: "arch=x86_64;distro=fedora-44"
+              - tmt_plan_regex: iot-x86
 ```
 
 ### 3. Testing Farm → TMT → test selection
@@ -168,19 +174,20 @@ elif [ "$TEST_CASE" = "iot-installer" ]; then
 
 ### 5. Test execution
 
-Each IoT test script derives the IoT version from `${COMPOSE}` (e.g. `Fedora-IoT-45-20260710.0` → `45`) and uses `IOT_VERSION` to select the correct OSTree ref, OS variant, and artifact name:
+Each IoT test script derives the IoT version from `${COMPOSE}` (e.g. `Fedora-IoT-46-20260815.0` → `46`) and uses `IOT_VERSION` to select the correct OSTree ref, OS variant, and artifact name:
 
 | `IOT_VERSION` | `OSTREE_REF` | `OS_VARIANT` |
 |---------------|------------|-----------|
 | `44` | `fedora/stable/${ARCH}/iot` | `fedora-unknown` |
-| `45` | `fedora/rawhide/${ARCH}/iot` | `fedora-rawhide` |
+| `45` | `fedora/devel/${ARCH}/iot` | `fedora-unknown` |
+| `46` | `fedora/rawhide/${ARCH}/iot` | `fedora-rawhide` |
 
 ### 6. Results reporting
 
 ```
-fedora-iot-{44,45}.yml (after Testing Farm completes)
+fedora-iot-{44,45,46}.yml (after Testing Farm completes)
     │
-    ├─ Updates PR status: ✅/❌ iot-f{44,45}-x86
+    ├─ Updates PR status: ✅/❌ iot-f{44,45,46}-x86
     │
     └─ Sends Slack notification to alerts-fedora-iot-compose-inspector (private):
          - Format: emoji distribution | architecture | compose ID | test log link
@@ -190,13 +197,13 @@ fedora-iot-{44,45}.yml (after Testing Farm completes)
 
 | File | Purpose | What it does |
 |------|---------|--------------|
-| `.github/workflows/trigger-iot.yml` | Detect compose | Checks for new F44/F45 composes, creates PRs, adds trigger comments |
+| `.github/workflows/trigger-iot.yml` | Detect compose | Checks for new F44/F45/F46 composes, creates PRs, adds trigger comments |
 | `.github/workflows/fedora-iot-44.yml` | Trigger F44 tests | Triggered by `/test-f44-iot`, calls Testing Farm with `Fedora-44` |
 | `.github/workflows/fedora-iot-45.yml` | Trigger F45 tests | Triggered by `/test-f45-iot`, calls Testing Farm with `Fedora-44` |
+| `.github/workflows/fedora-iot-46.yml` | Trigger F46 tests | Triggered by `/test-f46-iot`, calls Testing Farm with `Fedora-44` |
 | `compose/compose.f44-iot` | F44 compose history | Tracks already-tested F44 compose IDs |
 | `compose/compose.f45-iot` | F45 compose history | Tracks already-tested F45 compose IDs |
-| `files/fedora-44.json` | `osbuild-composer` repos | Fedora 44 stable repository definitions |
-| `files/fedora-45.json` | `osbuild-composer` repos | Fedora 45 Rawhide repository definitions |
+| `compose/compose.f46-iot` | F46 compose history | Tracks already-tested F46 compose IDs |
 | `tmt/plans/iot-test.fmf` | Test selection | Defines which tests run |
 | `tmt/tests/iot-test.fmf` | Test metadata | Points to `test.sh`, sets duration |
 | `tmt/tests/test.sh` | Test dispatcher | Selects which test script to run |


### PR DESCRIPTION
### What
Add CI infrastructure for Fedora IoT 46 testing and fix F45 `OS_VARIANT` now that it transitioned to devel.

### Why
Fedora IoT 46 has been created and needs to be tested. Follow-up to PR #12371 which updated F45 `OSTREE_REF` but not `OS_VARIANT`.

Assisted-by: Claude (claude-opus-4-6)